### PR TITLE
Fix version command

### DIFF
--- a/lib/ruby/signature/cli.rb
+++ b/lib/ruby/signature/cli.rb
@@ -275,7 +275,7 @@ module Ruby
         end
       end
 
-      def run_version(args)
+      def run_version(args, options)
         stdout.puts "ruby-signature #{VERSION}"
       end
 


### PR DESCRIPTION
This PR fixes the following error when running `exe/ruby-signature version` command:

```
$ exe/ruby-signature version
Traceback (most recent call last):
        2: from exe/ruby-signature:7:in `<main>'
        1: from /Users/koba/git/ybiquitous/ruby-signature/lib/ruby/signature/cli.rb:68:in `run'
/Users/koba/git/ybiquitous/ruby-signature/lib/ruby/signature/cli.rb:278:in `run_version': wrong number of arguments (given 2, expected 1) (ArgumentError)
```