### PR TITLE
Fix ast command

### DIFF
--- a/lib/ruby/signature/ast/declarations.rb
+++ b/lib/ruby/signature/ast/declarations.rb
@@ -233,7 +233,7 @@ module Ruby
               type: type,
               annotations: annotations,
               location: location
-            }
+            }.to_json(*a)
           end
         end
 
@@ -266,7 +266,7 @@ module Ruby
               name: name,
               type: type,
               location: location
-            }
+            }.to_json(*a)
           end
         end
 
@@ -299,7 +299,7 @@ module Ruby
               name: name,
               type: type,
               location: location
-            }
+            }.to_json(*a)
           end
         end
       end


### PR DESCRIPTION
I fixed `ast` command which failed due to the error below.

```
$ bundle exec exe/ruby-signature ast
bundler: failed to load command: exe/ruby-signature (exe/ruby-signature)
TypeError: wrong argument type Hash (expected String)
  /usr/local/Cellar/ruby/2.5.1/lib/ruby/2.5.0/json/common.rb:224:in `generate'
  /usr/local/Cellar/ruby/2.5.1/lib/ruby/2.5.0/json/common.rb:224:in `generate'
  /Users/ohbarye/.ghq/github.com/ohbarye/ruby-signature/lib/ruby/signature/cli.rb:86:in `run_ast'
  /Users/ohbarye/.ghq/github.com/ohbarye/ruby-signature/lib/ruby/signature/cli.rb:68:in `run'
  exe/ruby-signature:7:in `<top (required)>'
```

With 604c7af, the command got able to run correctly.