### PR TITLE
Add exception

### DIFF
--- a/stdlib/builtin/exception.rbi
+++ b/stdlib/builtin/exception.rbi
@@ -1,0 +1,17 @@
+class Exception
+  def self.exception: (*any) -> instance
+  def initialize: (?String?) -> void
+
+  def backtrace: -> Array[String]
+  def backtrace_locations: -> Array[any]
+  def cause: -> Exception?
+  def exception: -> self
+               | (String) -> self
+  def full_message: -> String
+  def inspect: -> String
+  def message: -> String
+  def to_s: -> String
+  def set_backtrace: (nil) -> nil
+                   | (String) -> String
+                   | (Array[String]) -> Array[String]
+end

--- a/stdlib/builtin/kernel.rbi
+++ b/stdlib/builtin/kernel.rbi
@@ -1,8 +1,20 @@
+interface _Exception0
+  def exception: () -> any
+end
+
+interface _Exception1[T]
+  def exception: (T) -> any
+end
+
 module Kernel
   private
-  def raise: () -> any
-           | (String) -> any
-           | (*any) -> any
+
+  def raise: () -> bot
+           | (String, ?cause: any) -> bot
+           | (_Exception0 exception_instance, ?cause: any) -> bot
+           | (_Exception1[T] exception_class, T message, ?Array[String]? backtrace, ?cause: any) -> bot
+
+  alias fail raise
 
   def block_given?: -> bool
   def enum_for: (Symbol, *any) -> any

--- a/stdlib/builtin/runtime_error.rbi
+++ b/stdlib/builtin/runtime_error.rbi
@@ -1,0 +1,2 @@
+class RuntimeError < StandardError
+end

--- a/stdlib/builtin/standard_error.rbi
+++ b/stdlib/builtin/standard_error.rbi
@@ -1,0 +1,2 @@
+class StandardError < Exception
+end


### PR DESCRIPTION
Add `Exception` class signature and `raise` method types.

The `raise` method signature supports two cases.

1. An instance of exception is specified. `raise ErrorClass.new(x: x, y: y, other: args)`
2. An exception class and `initialize` argument is specified. `raise ErrorClass, { x: x, y: y, other: args }`

The second case will overlook a lot of type errors because `Exception.exception` accepts `*any` in the definition. (We need even richer type language to give a precise definition for this.)