### PR TITLE
Add object type

### DIFF
--- a/lib/ruby/signature/types.rb
+++ b/lib/ruby/signature/types.rb
@@ -823,6 +823,42 @@ module Ruby
           literal.inspect
         end
       end
+
+      class Object
+        attr_reader :members
+        attr_reader :location
+
+        def initialize(members:, location:)
+          @members = members
+          @location = location
+        end
+
+        def ==(other)
+          other.is_a?(Object) && other.members == members
+        end
+
+        alias eql? ==
+
+        def hash
+          self.class.hash ^ members.hash
+        end
+
+        def to_json(*a)
+          {
+            class: :object,
+            members: members,
+            location: location
+          }.to_json(*a)
+        end
+
+        def to_s(level = 0)
+          s = members.each.with_object([]) do |(name, type), array|
+            array << "#{name}: #{type}"
+          end
+
+          "< #{s.join(", ")} >"
+        end
+      end
     end
   end
 end

--- a/test/ruby/signature/type_parsing_test.rb
+++ b/test/ruby/signature/type_parsing_test.rb
@@ -489,4 +489,15 @@ class Ruby::Signature::TypeParsingTest < Minitest::Test
       Parser.parse_type("Array[A]", variables: [:A, :Array])
     end
   end
+
+  def test_object_type
+    Parser.parse_type("< __id__: () -> Integer, as_json : () -> any >", variables: []).yield_self do |type|
+      assert_instance_of Types::Object, type
+
+      assert_equal [:__id__, :as_json].sort, type.members.keys.sort
+      assert_equal "() -> Integer", type.members[:__id__].to_s
+      assert_equal "() -> any", type.members[:as_json].to_s
+      assert_equal "< __id__: () -> Integer, as_json : () -> any >", type.location.source
+    end
+  end
 end


### PR DESCRIPTION
This PR is to add *object type*, which we denote `< to_s: () -> String >`.

* Do we support aliasing; something like `< ==: (A) -> bool > as A`?
  * We don't support aliasing to keep syntax & semantics clean. If you need complex types like recursive types, you can define an interface.
