### PR TITLE
Implement constant name resolution

### DIFF
--- a/lib/ruby/signature.rb
+++ b/lib/ruby/signature.rb
@@ -19,5 +19,7 @@ require "ruby/signature/builtin_names"
 require "ruby/signature/definition"
 require "ruby/signature/definition_builder"
 require "ruby/signature/substitution"
+require "ruby/signature/constant"
+require "ruby/signature/constant_table"
 
 require "ruby/signature/parser"

--- a/lib/ruby/signature/constant.rb
+++ b/lib/ruby/signature/constant.rb
@@ -1,0 +1,28 @@
+module Ruby
+  module Signature
+    class Constant
+      attr_reader :name
+      attr_reader :type
+      attr_reader :declaration
+
+      def initialize(name:, type:, declaration:)
+        @name = name
+        @type = type
+        @declaration = declaration
+      end
+
+      def ==(other)
+        other.is_a?(Constant) &&
+          other.name == name &&
+          other.type == type &&
+          other.declaration == declaration
+      end
+
+      alias eql? ==
+
+      def hash
+        self.class.hash ^ name.hash ^ type.hash ^ declaration.hash
+      end
+    end
+  end
+end

--- a/lib/ruby/signature/constant_table.rb
+++ b/lib/ruby/signature/constant_table.rb
@@ -1,0 +1,144 @@
+module Ruby
+  module Signature
+    class ConstantTable
+      attr_reader :definition_builder
+      attr_reader :constant_scopes_cache
+
+      def env
+        definition_builder.env
+      end
+
+      def initialize(builder:)
+        @definition_builder = builder
+        @constant_scopes_cache = {}
+      end
+
+      def name_to_constant(name)
+        case
+        when env.name_to_constant.key?(name)
+          decl = env.name_to_constant[name]
+          type = env.absolute_type(decl.type, namespace: name.namespace) {|type| type.name.absolute! }
+          Constant.new(name: name, type: type, declaration: decl)
+        when env.class?(name)
+          decl = env.name_to_decl[name]
+          type = Types::ClassSingleton.new(name: name, location: nil)
+          Constant.new(name: name, type: type, declaration: decl)
+        end
+      end
+
+      def split_name(name)
+        name.namespace.path + [name.name]
+      end
+
+      def resolve_constant_reference(name, context:)
+        head, *tail = split_name(name)
+
+        head_constant = case
+                        when name.absolute?
+                          name_to_constant(TypeName.new(name: head, namespace: Namespace.root))
+                        when !context || context.empty?
+                          name_to_constant(TypeName.new(name: head, namespace: Namespace.root))
+                        else
+                          resolve_constant_reference_context(head, context: context) ||
+                            resolve_constant_reference_inherit(head,
+                                                               scopes: constant_scopes(context.to_type_name))
+                        end
+
+        if head_constant
+          tail.inject(head_constant) do |constant, name|
+            resolve_constant_reference_inherit name,
+                                               scopes: constant_scopes(constant.name),
+                                               no_object: constant.name != BuiltinNames::Object.name
+          end
+        end
+      end
+
+      def resolve_constant_reference_context(name, context:)
+        if context.empty?
+          nil
+        else
+          name_to_constant(TypeName.new(name: name, namespace: context)) ||
+            resolve_constant_reference_context(name, context: context.parent)
+        end
+      end
+
+      def resolve_constant_reference_inherit(name, scopes:, no_object: false)
+        scopes.each do |context|
+          if context.path == [:Object]
+            unless no_object
+              constant = name_to_constant(TypeName.new(name: name, namespace: context)) ||
+                name_to_constant(TypeName.new(name: name, namespace: Namespace.root))
+            end
+          else
+            constant = name_to_constant(TypeName.new(name: name, namespace: context))
+          end
+
+          return constant if constant
+        end
+
+        nil
+      end
+
+      def constant_scopes(name)
+        constant_scopes_cache[name] ||= constant_scopes0(name, scopes: [])
+      end
+
+      def constant_scopes0(name, scopes: [])
+        decl = env.find_class(name)
+        namespace = name.to_namespace
+
+        case decl
+        when AST::Declarations::Module
+          decl.members.each do |member|
+            case member
+            when AST::Members::Include
+              constant_scopes0 absolute_type_name(member.name, namespace: namespace),
+                              scopes: scopes
+            end
+          end
+
+          scopes.unshift namespace
+
+        when AST::Declarations::Class
+          unless name == BuiltinNames::BasicObject.name
+            super_name = decl.super_class&.yield_self {|super_class|
+              absolute_type_name(super_class.name, namespace: namespace)
+            } || BuiltinNames::Object.name
+
+            constant_scopes0 super_name, scopes: scopes
+          end
+
+          decl.members.each do |member|
+            case member
+            when AST::Members::Include
+              constant_scopes0 absolute_type_name(member.name, namespace: namespace),
+                              scopes: scopes
+            end
+          end
+
+          scopes.unshift namespace
+        else
+          raise "Unexpected declaration: #{name}"
+        end
+
+        env.each_extension(name).sort_by {|e| e.extension_name.to_s }.each do |extension|
+          extension.members.each do |member|
+            case member
+            when AST::Members::Include
+              constant_scopes0 absolute_type_name(member.name, namespace: namespace),
+                              scopes: []
+            end
+          end
+        end
+
+        scopes
+      end
+
+      def absolute_type_name(name, namespace:)
+        env.absolute_type_name(name, namespace: namespace) do
+          raise
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby/signature/namespace.rb
+++ b/lib/ruby/signature/namespace.rb
@@ -72,6 +72,11 @@ module Ruby
         end
       end
 
+      def to_type_name
+        parent, name = split
+        TypeName.new(name: name, namespace: parent)
+      end
+
       def self.parse(string)
         if string.start_with?("::")
           new(path: string.split("::").drop(1).map(&:to_sym), absolute: true)

--- a/test/ruby/signature/constant_table_test.rb
+++ b/test/ruby/signature/constant_table_test.rb
@@ -1,0 +1,195 @@
+require "test_helper"
+
+class Ruby::Signature::ConstantTableTest < Minitest::Test
+  include TestHelper
+
+  ConstantTable = Ruby::Signature::ConstantTable
+  Constant = Ruby::Signature::Constant
+  TypeName = Ruby::Signature::TypeName
+  Namespace = Ruby::Signature::Namespace
+  DefinitionBuilder = Ruby::Signature::DefinitionBuilder
+
+  def test_name_to_constant
+    SignatureManager.new do |manager|
+      manager.files[Pathname("foo.rbi")] = <<EOF
+Name: String
+EOF
+
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+        table = ConstantTable.new(builder: builder)
+
+        table.name_to_constant(TypeName.new(name: :Object, namespace: Namespace.root)).tap do |constant|
+          assert_instance_of Constant, constant
+          assert_equal "::Object", constant.name.to_s
+          assert_equal "singleton(::Object)", constant.type.to_s
+        end
+
+        table.name_to_constant(TypeName.new(name: :Name, namespace: Namespace.root)).tap do |constant|
+          assert_instance_of Constant, constant
+          assert_equal "::Name", constant.name.to_s
+          assert_equal "::String", constant.type.to_s
+        end
+      end
+    end
+  end
+
+  def test_reference_top_level
+    SignatureManager.new do |manager|
+      manager.files[Pathname("foo.rbi")] = <<EOF
+Name: String
+EOF
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+        table = ConstantTable.new(builder: builder)
+
+        table.resolve_constant_reference(TypeName.new(name: :Name, namespace: Namespace.empty), context: nil).tap do |constant|
+          assert_instance_of Constant, constant
+          assert_equal "::Name", constant.name.to_s
+          assert_equal "::String", constant.type.to_s
+        end
+
+        table.resolve_constant_reference(TypeName.new(name: :ABC, namespace: Namespace.empty), context: nil).tap do |constant|
+          assert_nil constant
+        end
+      end
+    end
+  end
+
+  def test_reference_constant_context
+    SignatureManager.new do |manager|
+      manager.files[Pathname("foo.rbi")] = <<EOF
+class Foo
+end
+
+Name: "::Name"
+Foo::Name: "Foo::Name"
+EOF
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+        table = ConstantTable.new(builder: builder)
+        context = Namespace.parse("::Foo")
+
+        table.resolve_constant_reference(TypeName.new(name: :Name, namespace: Namespace.empty), context: context).tap do |constant|
+          assert_instance_of Constant, constant
+          assert_equal "::Foo::Name", constant.name.to_s
+          assert_equal '"Foo::Name"', constant.type.to_s
+        end
+
+        table.resolve_constant_reference(TypeName.new(name: :Name, namespace: Namespace.root), context: context).tap do |constant|
+          assert_instance_of Constant, constant
+          assert_equal "::Name", constant.name.to_s
+          assert_equal '"::Name"', constant.type.to_s
+        end
+      end
+    end
+  end
+
+  def test_reference_constant_inherit
+    SignatureManager.new do |manager|
+      manager.files[Pathname("foo.rbi")] = <<EOF
+class Parent
+end
+
+Parent::MAX: 10000
+
+class Child < Parent
+  include Mix
+end
+
+module Mix
+end
+
+Mix::MIN: 0
+EOF
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+        table = ConstantTable.new(builder: builder)
+
+        table.resolve_constant_reference(TypeName.new(name: :MAX, namespace: Namespace.empty), context: Namespace.parse("::Child")).tap do |constant|
+          assert_instance_of Constant, constant
+          assert_equal "::Parent::MAX", constant.name.to_s
+          assert_equal "10000", constant.type.to_s
+        end
+
+        table.resolve_constant_reference(TypeName.new(name: :MIN, namespace: Namespace.empty), context: Namespace.parse("::Child")).tap do |constant|
+          assert_instance_of Constant, constant
+          assert_equal "::Mix::MIN", constant.name.to_s
+          assert_equal '0', constant.type.to_s
+        end
+      end
+    end
+  end
+
+  def test_reference_constant_inherit2
+    SignatureManager.new do |manager|
+      manager.files[Pathname("foo.rbi")] = <<EOF
+class Foo
+end
+
+Foo::Name: "Foo::Name"
+EOF
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+        table = ConstantTable.new(builder: builder)
+
+        table.resolve_constant_reference(TypeName.new(name: :Name, namespace: Namespace.parse("Foo")), context: Namespace.parse("::Foo")).tap do |constant|
+          assert_instance_of Constant, constant
+          assert_equal "::Foo::Name", constant.name.to_s
+          assert_equal '"Foo::Name"', constant.type.to_s
+        end
+      end
+    end
+  end
+
+  def test_reference_constant_inherit3
+    SignatureManager.new do |manager|
+      manager.files[Pathname("foo.rbi")] = <<EOF
+class Stuff
+end
+
+ONE: 1
+Object::TWO: 2
+Kernel::THREE: 3
+BasicObject::FOUR: 4
+EOF
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+        table = ConstantTable.new(builder: builder)
+
+        table.resolve_constant_reference(TypeName.new(name: :ONE, namespace: Namespace.parse("Stuff")), context: nil).tap do |constant|
+          assert_nil constant
+        end
+
+        table.resolve_constant_reference(TypeName.new(name: :TWO, namespace: Namespace.parse("Stuff")), context: nil).tap do |constant|
+          assert_nil constant
+        end
+
+        table.resolve_constant_reference(TypeName.new(name: :THREE, namespace: Namespace.parse("Stuff")), context: nil).tap do |constant|
+          assert_instance_of Constant, constant
+          assert_equal "::Kernel::THREE", constant.name.to_s
+          assert_equal "3", constant.type.to_s
+        end
+
+        table.resolve_constant_reference(TypeName.new(name: :FOUR, namespace: Namespace.parse("Stuff")), context: nil).tap do |constant|
+          assert_instance_of Constant, constant
+          assert_equal "::BasicObject::FOUR", constant.name.to_s
+          assert_equal "4", constant.type.to_s
+        end
+      end
+    end
+  end
+
+  def test_split_name
+    SignatureManager.new do |manager|
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+        table = ConstantTable.new(builder: builder)
+
+        assert_equal [:Name], table.split_name(TypeName.new(name: :Name, namespace: Namespace.empty))
+        assert_equal [:X, :Y], table.split_name(TypeName.new(name: :Y, namespace: Namespace.parse("X")))
+        assert_equal [:X, :Y, :Z], table.split_name(TypeName.new(name: :Z, namespace: Namespace.parse("X::Y")))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add `Constant` and `ConstantTable` classes to simulate constant lookup in Ruby.

`ConstantTable` class provides `#resolve_constant_reference(name, context:)` method, which receives:

* `name` the name of the constant, and
* `context` the module/class context where the reference happens.

```rb
name = TypeName.new(name: :Foo, namespace: Namespace.empty)
context = Namespace.parse("::Hello::World")
constant = table.resolve_constant_reference(name, context: context)
```

The code above corresponds to the following Ruby code.

```rb
module Hello
  class World
    Foo     # <= Foo here
  end
end
```

The PR also adds `constant` command, which accepts `--context` option and constant name, and prints how the constant will be resolved and its type.