### PR TITLE
Dynamic method type

### DIFF
--- a/lib/ruby/signature/definition.rb
+++ b/lib/ruby/signature/definition.rb
@@ -39,7 +39,14 @@ module Ruby
         def sub(s)
           self.class.new(
             super_method: super_method&.sub(s),
-            method_types: method_types.map {|ty| ty.sub(s) },
+            method_types: method_types.map do |ty|
+              case ty
+              when MethodType
+                ty.sub(s)
+              when :any
+                ty
+              end
+            end,
             defined_in: defined_in,
             implemented_in: implemented_in,
             accessibility: @accessibility
@@ -50,7 +57,12 @@ module Ruby
           self.class.new(
             super_method: super_method&.map_type(&block),
             method_types: method_types.map do |ty|
-              ty.map_type(&block)
+              case ty
+              when MethodType
+                ty.map_type(&block)
+              when :any
+                ty
+              end
             end,
             defined_in: defined_in,
             implemented_in: implemented_in,
@@ -126,7 +138,12 @@ module Ruby
           methods.each_value do |method|
             if method.defined_in == self.declaration
               method.method_types.each do |method_type|
-                method_type.each_type(&block)
+                case method_type
+                when MethodType
+                  method_type.each_type(&block)
+                when :any
+                  # noop
+                end
               end
             end
           end

--- a/lib/ruby/signature/definition_builder.rb
+++ b/lib/ruby/signature/definition_builder.rb
@@ -340,6 +340,7 @@ module Ruby
               when AST::Members::MethodDefinition
                 if member.instance?
                   name = member.name
+
                   method_types = member.types.map do |method_type|
                     case method_type
                     when MethodType
@@ -348,6 +349,8 @@ module Ruby
                       end
                     when :super
                       :super
+                    when :any
+                      :any
                     end
                   end
 
@@ -527,8 +530,13 @@ module Ruby
               if member.singleton?
                 name = member.name
                 method_types = member.types.map do |method_type|
-                  method_type.map_type do |type|
-                    absolute_type(type, namespace: namespace)
+                  case method_type
+                  when MethodType
+                    method_type.map_type do |type|
+                      absolute_type(type, namespace: namespace)
+                    end
+                  when :any
+                    :any
                   end
                 end
 

--- a/lib/ruby/signature/definition_builder.rb
+++ b/lib/ruby/signature/definition_builder.rb
@@ -354,6 +354,10 @@ module Ruby
                     end
                   end
 
+                  if name == :initialize && !method_types.member?(:any)
+                    method_types << :any
+                  end
+
                   DuplicatedMethodDefinitionError.check!(
                     decl: decl,
                     methods: definition.methods,

--- a/lib/ruby/signature/parser.y
+++ b/lib/ruby/signature/parser.y
@@ -378,6 +378,7 @@ rule
   method_types:
       method_type { result = [val[0]] }
     | kSUPER { result = [LocatedValue.new(value: :super, location: val[0].location)] }
+    | kANY { result = [LocatedValue.new(value: :any, location: val[0].location)] }
     | method_type kBAR method_types {
         result = val[2].unshift(val[0])
       }

--- a/test/ruby/signature/definition_builder_test.rb
+++ b/test/ruby/signature/definition_builder_test.rb
@@ -558,11 +558,11 @@ EOF
         builder = DefinitionBuilder.new(env: env)
 
         builder.build_singleton(BuiltinNames::BasicObject.name).yield_self do |definition|
-          assert_equal ["() -> ::BasicObject"], definition.methods[:new].method_types.map {|x| x.to_s }
+          assert_equal ["() -> ::BasicObject", "any"], definition.methods[:new].method_types.map {|x| x.to_s }
         end
 
         builder.build_singleton(BuiltinNames::String.name).yield_self do |definition|
-          assert_equal ["() -> ::String"], definition.methods[:new].method_types.map {|x| x.to_s }
+          assert_equal ["() -> ::String", "any"], definition.methods[:new].method_types.map {|x| x.to_s }
         end
       end
     end

--- a/test/ruby/signature/signature_parsing_test.rb
+++ b/test/ruby/signature/signature_parsing_test.rb
@@ -734,4 +734,18 @@ end
       EOS
     end
   end
+
+  def test_dynamic_method_type
+    Parser.parse_signature(<<~SIG).yield_self do |decls|
+      class Foo
+        def eval: any
+      end
+    SIG
+
+      decls[0].members[0].yield_self do |m|
+        assert_instance_of Members::MethodDefinition, m
+        assert_equal :any, m.types[0]
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Problem

Some methods defined in Ruby are incompatible with `super` methods, like `.new` or `#initialize`.

```
class A < Object
  def initialize(name)         # A#initialize is incompatible with Object#initialize, and so is .new
    @name = name
  end
end
```

One possible type for `Object#initialize` is `(*any) -> any`. However, it allows passing any arguments to `Object.new`, which receives no argument. It is more general than any arguments but not less general than any other method types.

Examples: [I have defined a `#hash` method](https://github.com/soutaro/strong_json/blob/master/lib/strong_json/types.rb#L103-L105) for a runtime type checking utility for `Hash` object, which is incompatible with `Object#hash` method. [ActiveRecord has `#load` method](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-load), which is also incompatible with `Kernel#load`.

# `any` type

I'd like to propose to add a new method type `any`. It is like `any` type but ranges over method types.

```
class A < Object
  def initialize: (String) -> void
                | any
end
```

The `any` method type is both a super-type and sub-type of any method type.

The reason we need another `any` is that RBS type system has two different spaces of _types of values_ and _types of methods_. We already have `any` type for _types of values_, and the new `any` method type is for _types of methods_. In typical type systems, methods are values so that `?` type covers type of methods too. In RBS type system, `any` type is not for methods and we need another _any type_ for type of methods.

# Type checking

The `any` method type should be placed at the end of method overloadings, which means it has the lowest precedence. Like `any` type, type checkers can produce an (optional) error message to warn developers that the method type resolution may be different from what they want.

```
A.new()                     # It resolves to `any` method type and causes an error
```