### PR TITLE
Suppress syntactic warnings

### DIFF
--- a/lib/ruby/signature/definition.rb
+++ b/lib/ruby/signature/definition.rb
@@ -50,7 +50,7 @@ module Ruby
           self.class.new(
             super_method: super_method&.map_type(&block),
             method_types: method_types.map do |ty|
-              ty.map_type &block
+              ty.map_type(&block)
             end,
             defined_in: defined_in,
             implemented_in: implemented_in,

--- a/lib/ruby/signature/environment.rb
+++ b/lib/ruby/signature/environment.rb
@@ -104,7 +104,7 @@ module Ruby
       end
 
       def each_class_name(&block)
-        each_decl.select {|name,| class?(name) }.each &block
+        each_decl.select {|name,| class?(name) }.each(&block)
       end
 
       def class?(type_name)

--- a/lib/ruby/signature/environment_loader.rb
+++ b/lib/ruby/signature/environment_loader.rb
@@ -92,7 +92,7 @@ module Ruby
         signature_files = []
 
         if stdlib_root
-          signature_files.push *each_signature(stdlib_root + "builtin")
+          signature_files.push(*each_signature(stdlib_root + "builtin"))
         end
 
         each_signature do |path|

--- a/lib/ruby/signature/types.rb
+++ b/lib/ruby/signature/types.rb
@@ -677,13 +677,13 @@ module Ruby
         def map_type(&block)
           if block_given?
             Function.new(
-              required_positionals: required_positionals.map {|param| param.map_type &block },
-              optional_positionals: optional_positionals.map {|param| param.map_type &block },
-              rest_positionals: rest_positionals&.yield_self {|param| param.map_type &block },
-              trailing_positionals: trailing_positionals.map {|param| param.map_type &block },
-              required_keywords: required_keywords.transform_values {|param| param.map_type &block },
-              optional_keywords: optional_keywords.transform_values {|param| param.map_type &block },
-              rest_keywords: rest_keywords&.yield_self {|param| param.map_type &block },
+              required_positionals: required_positionals.map {|param| param.map_type(&block) },
+              optional_positionals: optional_positionals.map {|param| param.map_type(&block) },
+              rest_positionals: rest_positionals&.yield_self {|param| param.map_type(&block) },
+              trailing_positionals: trailing_positionals.map {|param| param.map_type(&block) },
+              required_keywords: required_keywords.transform_values {|param| param.map_type(&block) },
+              optional_keywords: optional_keywords.transform_values {|param| param.map_type(&block) },
+              rest_keywords: rest_keywords&.yield_self {|param| param.map_type(&block) },
               return_type: yield(return_type)
             )
           else


### PR DESCRIPTION
`rake` outputs a lot of "warning: `&' interpreted as argument prefix".
To suppress the warnings, this change adds explicit parentheses.