### PR TITLE
Initialize @eof explicitly to suppress tons of warnings

### DIFF
--- a/lib/ruby/signature/parser.y
+++ b/lib/ruby/signature/parser.y
@@ -930,6 +930,7 @@ def initialize(type, buffer:, eof_re:)
   @buffer = buffer
   @input = StringScanner.new(buffer.content)
   @eof_re = eof_re
+  @eof = false
   @bound_variables_stack = []
 end
 


### PR DESCRIPTION
"parser.y:1107: warning: instance variable @eof not initialized"