### PR TITLE
Add comments on decls and members

### DIFF
--- a/lib/ruby/signature.rb
+++ b/lib/ruby/signature.rb
@@ -22,5 +22,6 @@ require "ruby/signature/definition_builder"
 require "ruby/signature/substitution"
 require "ruby/signature/constant"
 require "ruby/signature/constant_table"
+require "ruby/signature/ast/comment"
 
 require "ruby/signature/parser"

--- a/lib/ruby/signature/ast/comment.rb
+++ b/lib/ruby/signature/ast/comment.rb
@@ -1,0 +1,29 @@
+module Ruby
+  module Signature
+    module AST
+      class Comment
+        attr_reader :string
+        attr_reader :location
+
+        def initialize(string:, location:)
+          @string = string
+          @location = location
+        end
+
+        def ==(other)
+          other.is_a?(Comment) && other.string == string
+        end
+
+        alias eql? ==
+
+        def hash
+          self.class.hash ^ string.hash
+        end
+
+        def to_json(*a)
+          { string: string, location: location }.to_json(*a)
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby/signature/ast/declarations.rb
+++ b/lib/ruby/signature/ast/declarations.rb
@@ -36,14 +36,16 @@ module Ruby
           attr_reader :super_class
           attr_reader :annotations
           attr_reader :location
+          attr_reader :comment
 
-          def initialize(name:, type_params:, super_class:, members:, annotations:, location:)
+          def initialize(name:, type_params:, super_class:, members:, annotations:, location:, comment:)
             @name = name
             @type_params = type_params
             @super_class = super_class
             @members = members
             @annotations = annotations
             @location = location
+            @comment = comment
           end
 
           def ==(other)
@@ -68,7 +70,8 @@ module Ruby
               members: members,
               super_class: super_class,
               annotations: annotations,
-              location: location
+              location: location,
+              comment: comment
             }.to_json(*a)
           end
         end
@@ -80,14 +83,16 @@ module Ruby
           attr_reader :location
           attr_reader :annotations
           attr_reader :self_type
+          attr_reader :comment
 
-          def initialize(name:, type_params:, members:, self_type:, annotations:, location:)
+          def initialize(name:, type_params:, members:, self_type:, annotations:, location:, comment:)
             @name = name
             @type_params = type_params
             @self_type = self_type
             @members = members
             @annotations = annotations
             @location = location
+            @comment = comment
           end
 
           def ==(other)
@@ -112,7 +117,8 @@ module Ruby
               members: members,
               self_type: self_type,
               annotations: annotations,
-              location: location
+              location: location,
+              comment: comment
             }.to_json(*a)
           end
         end
@@ -124,14 +130,16 @@ module Ruby
           attr_reader :members
           attr_reader :annotations
           attr_reader :location
+          attr_reader :comment
 
-          def initialize(name:, type_params:, extension_name:, members:, annotations:, location:)
+          def initialize(name:, type_params:, extension_name:, members:, annotations:, location:, comment:)
             @name = name
             @type_params = type_params
             @extension_name = extension_name
             @members = members
             @annotations = annotations
             @location = location
+            @comment = comment
           end
 
           def ==(other)
@@ -156,7 +164,8 @@ module Ruby
               extension_name: extension_name,
               members: members,
               annotations: annotations,
-              location: location
+              location: location,
+              comment: comment
             }.to_json(*a)
           end
         end
@@ -167,13 +176,15 @@ module Ruby
           attr_reader :members
           attr_reader :annotations
           attr_reader :location
+          attr_reader :comment
 
-          def initialize(name:, type_params:, members:, annotations:, location:)
+          def initialize(name:, type_params:, members:, annotations:, location:, comment:)
             @name = name
             @type_params = type_params
             @members = members
             @annotations = annotations
             @location = location
+            @comment = comment
           end
 
           def ==(other)
@@ -196,7 +207,8 @@ module Ruby
               type_params: type_params,
               members: members,
               annotations: annotations,
-              location: location
+              location: location,
+              comment: comment
             }.to_json(*a)
           end
         end
@@ -206,12 +218,14 @@ module Ruby
           attr_reader :type
           attr_reader :annotations
           attr_reader :location
+          attr_reader :comment
 
-          def initialize(name:, type:, annotations:, location:)
+          def initialize(name:, type:, annotations:, location:, comment:)
             @name = name
             @type = type
             @annotations = annotations
             @location = location
+            @comment = comment
           end
 
           def ==(other)
@@ -232,7 +246,8 @@ module Ruby
               name: name,
               type: type,
               annotations: annotations,
-              location: location
+              location: location,
+              comment: comment
             }.to_json(*a)
           end
         end
@@ -241,11 +256,13 @@ module Ruby
           attr_reader :name
           attr_reader :type
           attr_reader :location
+          attr_reader :comment
 
-          def initialize(name:, type:, location:)
+          def initialize(name:, type:, location:, comment:)
             @name = name
             @type = type
             @location = location
+            @comment = comment
           end
 
           def ==(other)
@@ -265,7 +282,8 @@ module Ruby
               declaration: :constant,
               name: name,
               type: type,
-              location: location
+              location: location,
+              comment: comment
             }.to_json(*a)
           end
         end
@@ -274,11 +292,13 @@ module Ruby
           attr_reader :name
           attr_reader :type
           attr_reader :location
+          attr_reader :comment
 
-          def initialize(name:, type:, location:)
+          def initialize(name:, type:, location:, comment:)
             @name = name
             @type = type
             @location = location
+            @comment = comment
           end
 
           def ==(other)
@@ -298,7 +318,8 @@ module Ruby
               declaration: :global,
               name: name,
               type: type,
-              location: location
+              location: location,
+              comment: comment
             }.to_json(*a)
           end
         end

--- a/lib/ruby/signature/ast/members.rb
+++ b/lib/ruby/signature/ast/members.rb
@@ -8,13 +8,15 @@ module Ruby
           attr_reader :types
           attr_reader :annotations
           attr_reader :location
+          attr_reader :comment
 
-          def initialize(name:, kind:, types:, annotations:, location:)
+          def initialize(name:, kind:, types:, annotations:, location:, comment:)
             @name = name
             @kind = kind
             @types = types
             @annotations = annotations
             @location = location
+            @comment = comment
           end
 
           def ==(other)
@@ -44,7 +46,8 @@ module Ruby
               kind: kind,
               types: types,
               annotations: annotations,
-              location: location
+              location: location,
+              comment: comment
             }.to_json(*a)
           end
         end
@@ -53,11 +56,13 @@ module Ruby
           attr_reader :name
           attr_reader :type
           attr_reader :location
+          attr_reader :comment
 
-          def initialize(name:, type:, location:)
+          def initialize(name:, type:, location:, comment:)
             @name = name
             @type = type
             @location = location
+            @comment = comment
           end
 
           def ==(other)
@@ -79,7 +84,8 @@ module Ruby
               member: :instance_variable,
               name: name,
               type: type,
-              location: location
+              location: location,
+              comment: comment
             }.to_json(*a)
           end
         end
@@ -92,7 +98,8 @@ module Ruby
               member: :class_instance_variable,
               name: name,
               type: type,
-              location: location
+              location: location,
+              comment: comment
             }.to_json(*a)
           end
         end
@@ -105,7 +112,8 @@ module Ruby
               member: :class_variable,
               name: name,
               type: type,
-              location: location
+              location: location,
+              comment: comment
             }.to_json(*a)
           end
         end
@@ -115,12 +123,14 @@ module Ruby
           attr_reader :args
           attr_reader :annotations
           attr_reader :location
+          attr_reader :comment
 
-          def initialize(name:, args:, annotations:, location:)
+          def initialize(name:, args:, annotations:, location:, comment:)
             @name = name
             @args = args
             @annotations = annotations
             @location = location
+            @comment = comment
           end
 
           def ==(other)
@@ -145,7 +155,8 @@ module Ruby
               name: name,
               args: args,
               annotations: annotations,
-              location: location
+              location: location,
+              comment: comment
             }.to_json(*a)
           end
         end
@@ -159,7 +170,8 @@ module Ruby
               name: name,
               args: args,
               annotations: annotations,
-              location: location
+              location: location,
+              comment: comment
             }.to_json(*a)
           end
         end
@@ -173,7 +185,8 @@ module Ruby
               name: name,
               args: args,
               annotations: annotations,
-              location: location
+              location: location,
+              comment: comment
             }.to_json(*a)
           end
         end
@@ -184,13 +197,15 @@ module Ruby
           attr_reader :ivar_name
           attr_reader :annotations
           attr_reader :location
+          attr_reader :comment
 
-          def initialize(name:, type:, ivar_name:, annotations:, location:)
+          def initialize(name:, type:, ivar_name:, annotations:, location:, comment:)
             @name = name
             @type = type
             @ivar_name = ivar_name
             @annotations = annotations
             @location = location
+            @comment = comment
           end
 
           def ==(other)
@@ -217,7 +232,8 @@ module Ruby
               type: type,
               ivar_name: ivar_name,
               annotations: annotations,
-              location: location
+              location: location,
+              comment: comment
             }.to_json(*a)
           end
         end
@@ -232,7 +248,8 @@ module Ruby
               type: type,
               ivar_name: ivar_name,
               annotations: annotations,
-              location: location
+              location: location,
+              comment: comment
             }.to_json(*a)
           end
         end
@@ -247,7 +264,8 @@ module Ruby
               type: type,
               ivar_name: ivar_name,
               annotations: annotations,
-              location: location
+              location: location,
+              comment: comment
             }.to_json(*a)
           end
         end
@@ -292,13 +310,15 @@ module Ruby
           attr_reader :kind
           attr_reader :annotations
           attr_reader :location
+          attr_reader :comment
 
-          def initialize(new_name:, old_name:, kind:, annotations:, location:)
+          def initialize(new_name:, old_name:, kind:, annotations:, location:, comment:)
             @new_name = new_name
             @old_name = old_name
             @kind = kind
             @annotations = annotations
             @location = location
+            @comment = comment
           end
 
           def ==(other)
@@ -321,7 +341,8 @@ module Ruby
               old_name: old_name,
               kind: kind,
               annotations: annotations,
-              location: location
+              location: location,
+              comment: comment
             }.to_json(*a)
           end
 


### PR DESCRIPTION
Add `comment` attribute on declarations and members so that developers can add comments in RBS subjects.