### PR TITLE
Add signatures for some String methods

### DIFF
--- a/stdlib/builtin/string.rbi
+++ b/stdlib/builtin/string.rbi
@@ -42,4 +42,8 @@ class String
   def to_i: -> Integer
           | (Integer) -> Integer
   def end_with?: (*String) -> bool
+  def strip: -> String
+  def strip!: -> self?
+  def casecmp: (String) -> Integer?
+  def casecmp?: (String) -> bool?
 end


### PR DESCRIPTION
Hi, this PR adds signatures of the methods below:

- [`strip`](http://ruby-doc.org/core-2.6.3/String.html#method-i-strip)
- [`strip!`](http://ruby-doc.org/core-2.6.3/String.html#method-i-strip-21)
- [`casecmp`](http://ruby-doc.org/core-2.6.3/String.html#method-i-casecmp)
- [`casecmp?`](http://ruby-doc.org/core-2.6.3/String.html#method-i-casecmp-3F)

The ruby-doc.org API documentation helps me write these changes.

If this PR does not follow the repository manner, please tell me the correct one. I'm prepare to follow.
Thanks.

See also #1 