### PR TITLE
Add runtime test feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ $ ruby-signature -r set list
 $ ruby-signature -I sig list
 ```
 
+## Guides
+
+- [Writing signatures guide](doc/sigs.md)
+- [Stdlib signatures guide](doc/stdlib.md)
+- [Syntax](doc/syntax.md)
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/Rakefile
+++ b/Rakefile
@@ -4,10 +4,16 @@ require "rake/testtask"
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList["test/**/*_test.rb"]
+  t.test_files = FileList["test/**/*_test.rb"].reject do |path|
+    path =~ %r{test/stdlib/}
+  end
 end
 
-task :default => :test
+task :default => [:test, :stdlib_test]
+
+task :stdlib_test do
+  sh "ruby bin/test_runner.rb"
+end
 
 rule ".rb" => ".y" do |t|
   sh "racc -v -o #{t.name} #{t.source}"
@@ -15,6 +21,7 @@ end
 
 task :parser => "lib/ruby/signature/parser.rb"
 task :test => :parser
+task :stdlib_test => :parser
 task :build => :parser
 
 CLEAN.include("lib/ruby/signature/parser.rb")

--- a/bin/test_runner.rb
+++ b/bin/test_runner.rb
@@ -1,0 +1,54 @@
+require "ruby/signature"
+require "ruby/signature/test"
+require "minitest/autorun"
+
+logger = Logger.new(STDERR)
+logger.level = ENV["RBS_TEST_LOGLEVEL"] || "info"
+
+env = Ruby::Signature::Environment.new
+loader = Ruby::Signature::EnvironmentLoader.new
+loader.load(env: env)
+
+HOOKS = {}
+
+class StdlibTest < Minitest::Test
+  def self.target(klass)
+    @target = klass
+  end
+
+  def self.hook
+    HOOKS[@target]
+  end
+
+  def hook
+    self.class.hook
+  end
+
+  def setup
+    super
+    self.class.hook.errors.clear
+    @assert = true
+  end
+
+  def teardown
+    super
+    assert_empty self.class.hook.errors.map {|x| Ruby::Signature::Test::Hook::Errors.to_string(x) }
+  end
+end
+
+class_names = if ARGV.empty?
+                Pathname("test/stdlib").children.map do |path|
+                  basename = path.basename.to_s
+                  if (m = basename.match(/(?<name>(?~_test))_test.rb/))
+                    m[:name].gsub(/__/, "::")
+                  end
+                end.compact
+              else
+                ARGV
+              end
+
+class_names.each do |class_name|
+  klass = ::Object.const_get(class_name)
+  HOOKS[klass] = Ruby::Signature::Test::Hook.new(env, klass, logger: logger).verify_all
+  load "test/stdlib/#{class_name.gsub(/::/, "__")}_test.rb"
+end

--- a/doc/sigs.md
+++ b/doc/sigs.md
@@ -1,0 +1,142 @@
+# Writing Signatures Guide
+
+You can write the signature of your applications and libraries.
+Signature of your Ruby program would help:
+
+1. Understanding the code structure
+2. Finding APIs
+
+And if you ship your gem with signature, the gem users can type check their applications!
+
+## Writing signatures
+
+You first need to write your program's signature.
+See [syntax guide](syntax.md).
+
+## Testing signatures
+
+When you finish writing signature, you may want to test the signature.
+ruby-signature provides a feature to test your signature.
+
+```
+$ RBS_TEST_TARGET='Foo::*' bundle exec ruby -r ruby/signature/test/setup test/foo_test.rb
+```
+
+The test installs instrumentations to spy the method calls and check if arguments/return values are correct with respect to the type of the method in signature.
+If errors are reported by the test, you will fix the signature.
+You will be sure that you ship a correct signature finally.
+
+The instrumentations are implemneted using `Module#prepend`.
+It defines a module with same name of methods, which asserts the type of arguments/return values and calls `super`.
+
+## Type errors
+
+If the test detects type errors, it will print error messages.
+
+### ArgumentTypeError, BlockArgumentTypeError
+
+The message means there is an unexpected type of argument or block argument.
+
+```
+ERROR -- : [Kaigi::Speaker.new] ArgumentTypeError: expected `::String` (email) but given `:"matsumoto@soutaro.com"`
+```
+
+### ArgumentError, BlockArgumentError
+
+The message means there is an unexpected argument or missing argument.
+
+```
+[Kaigi::Speaker.new] ArgumentError: expected method type (size: ::Symbol, email: ::String, name: ::String) -> ::Kaigi::Speaker
+```
+
+### ReturnTypeError, BlockReturnTypeError
+
+The message means the return value from method or block is incorrect.
+
+```
+ERROR -- : [Kaigi::Conference#each_speaker] ReturnTypeError: expected `self` but returns `[#<Kaigi::Speaker:0x00007fb2b249e5a0 @name="Soutaro Matsumoto", @email=:"matsumoto@soutaro.com">]`
+```
+
+### UnexpectedBlockError, MissingBlockError
+
+The errors are reported when required block is not given or unused block is given.
+
+```
+ERROR -- : [Kaigi::Conference#speakers] UnexpectedBlockError: unexpected block is given for `() -> ::Array[::Kaigi::Speaker]`
+```
+
+### UnresolvedOverloadingError
+
+The error means there is a type error on overloaded methods.
+The `ruby-signature` test framework tries to the best error message for overloaded methods too, but it reports the `UnresolvedOverloadingError` when it fails.
+
+## Setting up the test
+
+The design of the signature testing aims to be non-intrusive. The setup is done in two steps:
+
+1. Loading the testing library
+2. Setting up the test through environment variables
+
+### Loading the library
+
+You need to require `ruby/signature/test/setup` for signature testing.
+You can do it using `-r` option through command line argument or the `RUBYOPT` environment variable.
+
+```
+$ ruby -r ruby/signature/test/setup run_tests.rb
+$ RUBYOPT='-rruby/signature/test/setup' rake test
+```
+
+When you are using Bundler, you may need to require `bundler/setup` explicitly.
+
+```
+$ RUBYOPT='-rbundler/setup -rruby/signature/test/setup' bundle exec rake test
+```
+
+### Environment variables
+
+You need to specify `RBS_TEST_TARGET` to run the test, and you can customize the test with the following environment variables.
+
+- `RBS_TEST_SKIP` (optional)
+- `RBS_TEST_OPT` (optional)
+- `RBS_TEST_LOGLEVEL` (optional)
+
+`RBS_TEST_TARGET` is to specify the classes you want to test. `RBS_TEST_TARGET` can contain comma-separated class name pattern, which is one of an exact class name or with wildcard `*`.
+
+- `RBS_TEST_TARGET=Foo::Bar,Foo::Baz` comma separated exact class names
+- `RBS_TEST_TARGET=Foo::*` using wildcard
+
+`RBS_TEST_SKIP` is to skip some of the classes which matches with `RBS_TEST_TARGET`.
+
+`RBS_TEST_OPT` is to pass the options for ruby signature handling.
+You may need to specify `-r` or `-I` to load signatures.
+The default is `-I sig`.
+
+```
+RBS_TEST_OPT='-r set -r pathname -I sig'
+```
+
+`RBS_TEST_LOGLEVEL` can be used to configure log level. Defaults to `info`.
+
+So, a typical command line to start the test would look like the following:
+
+```
+$ RBS_TEST_LOGLEVEL=error \
+  RBS_TEST_TARGET='Kaigi::*' \
+  RBS_TEST_SKIP='Kaigi::MonkeyPatch' \
+  RBS_TEST_OPT='-rset -rpathname -Isig -Iprivate' \
+  RUBY_OPT='-rbundler/setup -rruby/signature/test/setup' \
+  bundle exec rake test
+```
+
+## Testing tips
+
+### Skipping a method
+
+You can skip installing the instrumentation per-method basis using `rbs:test:skip` annotation.
+
+```
+class String
+  %a{rbs:test:skip} def =~: (Regexp) -> Integer?
+end
+```

--- a/doc/stdlib.md
+++ b/doc/stdlib.md
@@ -1,0 +1,52 @@
+# Stdlib Signatures Guide
+
+This is a guide for contributing to `ruby-signature` by writing/revising stdlib signatures.
+
+## Signatures
+
+Signatures for standard libraries are located in `stdlib` directory. `stdlib/builtin` is for builtin libraries. Other libraries have directories like `stdlibt/set` or `stdlib/pathname`.
+
+To write signatures see [syntax guide](`syntax.md`).
+
+## Testing
+
+We support writing tests for stdlib signatures.
+
+### Writing tests
+
+Put the test scripts in `test/stdlib` directory with `[class_name]_test.rb`, like `String_test.rb` and `File_test.rb`.
+The test scripts would look like the following:
+
+```rb
+class StringTest < StdlibTest
+  target String
+  using hook.refinement
+
+  def test_gsub
+    s = "string"
+    s.gsub(/./, "")
+    s.gsub("a", "b")
+    s.gsub(/./) {|x| "" }
+    s.gsub(/./, {"foo" => "bar"})
+    s.gsub(/./)
+    s.gsub("")
+  end
+end
+```
+
+You need two method calls, `target` and `using`.
+`target` method call tells which class is the subject of the class.
+`using hook.refinement` installs a special instrumentation for stdlib, based on refinements.
+And you write the sample programs which calls all of the patterns of overloads.
+
+Note that the instrumentation is based on refinmenets and you need to write all method calls in the unit class definitions.
+If the execution of the program escape from the class definition, the instrumentation is disabled and no check will be done.
+
+### Running tests
+
+You can run the test with:
+
+```
+$ bundle exec ruby bin/test_runner.rb              # Run all tests
+$ bundle exec ruby bin/test_runner.rb String Hash  # Run specific tests
+```

--- a/lib/ruby/signature.rb
+++ b/lib/ruby/signature.rb
@@ -5,6 +5,7 @@ require "json"
 require "pathname"
 require "pp"
 require "ripper"
+require "logger"
 
 require "ruby/signature/errors"
 require "ruby/signature/buffer"

--- a/lib/ruby/signature/definition.rb
+++ b/lib/ruby/signature/definition.rb
@@ -20,14 +20,16 @@ module Ruby
         attr_reader :implemented_in
         attr_reader :accessibility
         attr_reader :attributes
+        attr_reader :annotations
 
-        def initialize(super_method:, method_types:, defined_in:, implemented_in:, accessibility:, attributes:)
+        def initialize(super_method:, method_types:, defined_in:, implemented_in:, accessibility:, attributes:, annotations:)
           @super_method = super_method
           @method_types = method_types
           @defined_in = defined_in
           @implemented_in = implemented_in
           @accessibility = accessibility
           @attributes = attributes
+          @annotations = annotations
         end
 
         def public?
@@ -45,7 +47,8 @@ module Ruby
             defined_in: defined_in,
             implemented_in: implemented_in,
             accessibility: @accessibility,
-            attributes: attributes
+            attributes: attributes,
+            annotations: annotations
           )
         end
 
@@ -58,7 +61,8 @@ module Ruby
             defined_in: defined_in,
             implemented_in: implemented_in,
             accessibility: @accessibility,
-            attributes: attributes
+            attributes: attributes,
+            annotations: annotations
           )
         end
       end

--- a/lib/ruby/signature/definition_builder.rb
+++ b/lib/ruby/signature/definition_builder.rb
@@ -294,7 +294,8 @@ module Ruby
                     implemented_in: env.find_class(Ruby::Signature::BuiltinNames::Class.name),
                     method_types: method_types,
                     accessibility: :public,
-                    attributes: [:incompatible]
+                    attributes: [:incompatible],
+                    annotations: []
                   )
                 end
               end
@@ -367,7 +368,8 @@ module Ruby
                                                                     defined_in: decl,
                                                                     implemented_in: decl,
                                                                     accessibility: accessibility,
-                                                                    attributes: attrs)
+                                                                    attributes: attrs,
+                                                                    annotations: member.annotations)
                 end
               when AST::Members::AttrReader, AST::Members::AttrAccessor, AST::Members::AttrWriter
                 name = member.name
@@ -393,7 +395,8 @@ module Ruby
                     defined_in: decl,
                     implemented_in: decl,
                     accessibility: accessibility,
-                    attributes: []
+                    attributes: [],
+                    annotations: member.annotations
                   )
                 end
 
@@ -418,7 +421,8 @@ module Ruby
                     defined_in: decl,
                     implemented_in: decl,
                     accessibility: accessibility,
-                    attributes: []
+                    attributes: [],
+                    annotations: member.annotations
                   )
                 end
 
@@ -483,7 +487,8 @@ module Ruby
                       defined_in: method.defined_in,
                       implemented_in: decl,
                       accessibility: method.accessibility,
-                      attributes: []
+                      attributes: [],
+                      annotations: method.annotations
                     )
                   end
                 end
@@ -548,7 +553,8 @@ module Ruby
                                                                   defined_in: decl,
                                                                   implemented_in: decl,
                                                                   accessibility: accessibility,
-                                                                  attributes: member.attributes)
+                                                                  attributes: member.attributes,
+                                                                  annotations: member.annotations)
               end
             when AST::Members::Alias
               if member.singleton?
@@ -603,7 +609,8 @@ module Ruby
                     defined_in: method.defined_in,
                     implemented_in: decl,
                     accessibility: method.accessibility,
-                    attributes: method.attributes
+                    attributes: method.attributes,
+                    annotations: method.annotations
                   )
                 end
               end
@@ -676,7 +683,8 @@ module Ruby
           defined_in: method.defined_in,
           implemented_in: method.implemented_in,
           accessibility: method.accessibility,
-          attributes: method.attributes
+          attributes: method.attributes,
+          annotations: method.annotations
         )
       end
 
@@ -745,7 +753,8 @@ module Ruby
                 defined_in: declaration,
                 implemented_in: nil,
                 accessibility: :public,
-                attributes: member.attributes
+                attributes: member.attributes,
+                annotations: member.annotations
               )
               definition.methods[member.name] = method
             when AST::Members::Alias

--- a/lib/ruby/signature/test.rb
+++ b/lib/ruby/signature/test.rb
@@ -1,0 +1,1 @@
+require "ruby/signature/test/hook"

--- a/lib/ruby/signature/test/hook.rb
+++ b/lib/ruby/signature/test/hook.rb
@@ -1,0 +1,468 @@
+require "ruby/signature"
+
+module Ruby
+  module Signature
+    module Test
+      class Hook
+        IS_AP = Object.instance_method(:is_a?)
+        DEFINE_METHOD = Module.instance_method(:define_method)
+        INSTANCE_EVAL = BasicObject.instance_method(:instance_eval)
+        INSTANCE_EXEC = BasicObject.instance_method(:instance_exec)
+        METHOD = Kernel.instance_method(:method)
+
+        module Errors
+          ArgumentTypeError =
+            Struct.new(:klass, :method_name, :method_type, :param, :value, keyword_init: true)
+          BlockArgumentTypeError =
+            Struct.new(:klass, :method_name, :method_type, :param, :value, keyword_init: true)
+          ArgumentError =
+            Struct.new(:klass, :method_name, :method_type, keyword_init: true)
+          BlockArgumentError =
+            Struct.new(:klass, :method_name, :method_type, keyword_init: true)
+          ReturnTypeError =
+            Struct.new(:klass, :method_name, :method_type, :type, :value, keyword_init: true)
+          BlockReturnTypeError =
+            Struct.new(:klass, :method_name, :method_type, :type, :value, keyword_init: true)
+
+          UnexpectedBlockError = Struct.new(:klass, :method_name, :method_type, keyword_init: true)
+          MissingBlockError = Struct.new(:klass, :method_name, :method_type, keyword_init: true)
+
+          UnresolvedOverloadingError = Struct.new(:klass, :method_name, :method_types, keyword_init: true)
+
+          def self.format_param(param)
+            if param.name
+              "`#{param.type}` (#{param.name})"
+            else
+              "`#{param.type}`"
+            end
+          end
+
+          def self.to_string(error)
+            method = "#{error.klass.name}#{error.method_name}"
+            case error
+            when ArgumentTypeError
+              "[#{method}] ArgumentTypeError: expected #{format_param error.param} but given `#{error.value.inspect}`"
+            when BlockArgumentTypeError
+              "[#{method}] BlockArgumentTypeError: expected #{format_param error.param} but given `#{error.value.inspect}`"
+            when ArgumentError
+              "[#{method}] ArgumentError: expected method type #{error.method_type}"
+            when BlockArgumentError
+              "[#{method}] BlockArgumentError: expected method type #{error.method_type}"
+            when ReturnTypeError
+              "[#{method}] ReturnTypeError: expected `#{error.type}` but returns `#{error.value.inspect}`"
+            when BlockReturnTypeError
+              "[#{method}] BlockReturnTypeError: expected `#{error.type}` but returns `#{error.value.inspect}`"
+            when UnexpectedBlockError
+              "[#{method}] UnexpectedBlockError: unexpected block is given for `#{error.method_type}`"
+            when MissingBlockError
+              "[#{method}] MissingBlockError: required block is missing for `#{error.method_type}`"
+            when UnresolvedOverloadingError
+              "[#{method}] UnresolvedOverloadingError: couldn't find a suitable overloading"
+            else
+              raise "Unexpected error: #{error.inspect}"
+            end
+          end
+        end
+
+        attr_reader :env
+        attr_reader :logger
+
+        attr_reader :instance_module
+        attr_reader :instance_methods
+        attr_reader :singleton_module
+        attr_reader :singleton_methods
+
+        attr_reader :klass
+        attr_reader :errors
+
+        ArgsReturn = Struct.new(:arguments, :return_value, keyword_init: true)
+        Call = Struct.new(:method_call, :block_call, :block_given, keyword_init: true)
+
+        def initialize(env, klass, logger:)
+          @env = env
+          @logger = logger
+          @klass = klass
+
+          @instance_module = Module.new
+          @instance_methods = []
+
+          @singleton_module = Module.new
+          @singleton_methods = []
+
+          @errors = []
+
+          klass.prepend @instance_module
+          klass.singleton_class.prepend @singleton_module
+        end
+
+        def verify_all
+          type_name = Namespace.parse(klass.name).to_type_name.absolute!
+
+          builder = DefinitionBuilder.new(env: env)
+          builder.build_instance(type_name).tap do |definition|
+            definition.methods.each do |name, method|
+              if method.defined_in.name.absolute! == type_name
+                unless method.annotations.any? {|a| a.string == "rbs:test:skip" }
+                  logger.info "Installing hook on #{type_name}##{name}: #{method.method_types.join(" | ")}"
+                  verify instance_method: name, types: method.method_types
+                else
+                  logger.info "Skipping test of #{type_name}##{name}"
+                end
+              end
+            end
+          end
+
+          builder.build_singleton(type_name).tap do |definition|
+            definition.methods.each do |name, method|
+              if method.defined_in&.name&.absolute! == type_name
+                unless method.annotations.any? {|a| a.string == "rbs:test:skip" }
+                  logger.info "Installing hook on #{type_name}.#{name}: #{method.method_types.join(" | ")}"
+                  verify singleton_method: name, types: method.method_types
+                else
+                  logger.info "Skipping test of #{type_name}##{name}"
+                end
+              end
+            end
+          end
+
+          self
+        end
+
+        def delegation(name, method_types, method_name)
+          hook = self
+
+          proc do |*args, &block|
+            hook.logger.debug { "#{method_name} receives arguments: #{args.inspect}" }
+
+            block_call = nil
+
+            if block
+              original_block = block
+
+              block = hook.call(Object.new, INSTANCE_EVAL) do |fresh_obj|
+                proc do |*as|
+                  hook.logger.debug { "#{method_name} receives block arguments: #{as.inspect}" }
+
+                  ret = if self.equal?(fresh_obj)
+                          original_block[*as]
+                        else
+                          hook.call(self, INSTANCE_EXEC, *as, &original_block)
+                        end
+
+                  block_call = ArgsReturn.new(arguments: as, return_value: ret)
+
+                  hook.logger.debug { "#{method_name} returns from block: #{ret.inspect}" }
+
+                  ret
+                end
+              end
+            end
+
+            method = self.method(name)
+            result = method.super_method.call(*args, &block)
+
+            hook.logger.debug { "#{method_name} returns: #{result.inspect}" }
+
+            call = Call.new(method_call: ArgsReturn.new(arguments: args, return_value: result),
+                            block_call: block_call,
+                            block_given: block != nil)
+
+            errorss = method_types.map do |method_type|
+              hook.test(method_name, method_type, call)
+            end
+
+            new_errors = []
+
+            if errorss.none?(&:empty?)
+              if (best_errors = hook.find_best_errors(errorss))
+                new_errors.push *best_errors
+              else
+                new_errors << Errors::UnresolvedOverloadingError.new(
+                  klass: hook.klass,
+                  method_name: method_name,
+                  method_types: method_types
+                )
+              end
+            end
+
+            new_errors.each do |error|
+              hook.logger.error Errors.to_string(error)
+            end
+
+            hook.errors.push *new_errors
+            result
+          end
+        end
+
+        def verify(instance_method: nil, singleton_method: nil, types:)
+          method_types = types.map do |type|
+            case type
+            when String
+              Parser.parse_method_type(type)
+            else
+              type
+            end
+          end
+
+          case
+          when instance_method
+            instance_methods << instance_method
+            call(self.instance_module, DEFINE_METHOD, instance_method, &delegation(instance_method, method_types, "##{instance_method}"))
+          when singleton_method
+            call(self.singleton_module, DEFINE_METHOD, singleton_method, &delegation(singleton_method, method_types, ".#{singleton_method}"))
+          end
+          self
+        end
+
+        def find_best_errors(errorss)
+          if errorss.size == 1
+            errorss[0]
+          else
+            no_arity_errors = errorss.select do |errors|
+              errors.none? do |error|
+                error.is_a?(Errors::ArgumentError) ||
+                  error.is_a?(Errors::BlockArgumentError) ||
+                  error.is_a?(Errors::MissingBlockError) ||
+                  error.is_a?(Errors::UnexpectedBlockError)
+              end
+            end
+
+            unless no_arity_errors.empty?
+              # Choose a error set which doesn't include arity error
+              return no_arity_errors[0] if no_arity_errors.size == 1
+            end
+          end
+        end
+
+        def self.backtrace(skip: 2)
+          raise
+        rescue => exn
+          exn.backtrace.drop(skip)
+        end
+
+        def test(method_name, method_type, call)
+          errors = []
+
+          typecheck_args(method_name, method_type, method_type.type, call.method_call, errors, type_error: Errors::ArgumentTypeError, argument_error: Errors::ArgumentError)
+          typecheck_return(method_name, method_type, method_type.type, call.method_call, errors, return_error: Errors::ReturnTypeError)
+
+          if method_type.block
+            if call.block_call
+              typecheck_args(method_name, method_type, block_args(method_type.block.type), call.block_call, errors, type_error: Errors::BlockArgumentTypeError, argument_error: Errors::BlockArgumentError)
+              typecheck_return(method_name, method_type, method_type.block.type, call.block_call, errors, return_error: Errors::BlockReturnTypeError)
+            else
+              if method_type.block.required
+                errors << Errors::MissingBlockError.new(klass: klass, method_name: method_name, method_type: method_type)
+              end
+            end
+          else
+            if call.block_given
+              errors << Errors::UnexpectedBlockError.new(klass: klass, method_name: method_name, method_type: method_type)
+            end
+          end
+
+          errors
+        end
+
+        def run
+          yield
+          self
+        ensure
+          disable
+        end
+
+        def call(receiver, method, *args, &block)
+          method.bind(receiver).call(*args, &block)
+        end
+
+        def disable
+          self.instance_module.remove_method *instance_methods
+          self.singleton_module.remove_method *singleton_methods
+          self
+        end
+
+        def typecheck_args(method_name, method_type, fun, value, errors, type_error:, argument_error:)
+          test = zip_args(value.arguments, fun) do |value, param|
+            unless type_check(value, param.type)
+              errors << type_error.new(klass: klass,
+                                       method_name: method_name,
+                                       method_type: method_type,
+                                       param: param,
+                                       value: value)
+            end
+          end
+
+          unless test
+            errors << argument_error.new(klass: klass,
+                                         method_name: method_name,
+                                         method_type: method_type)
+          end
+        end
+
+        def typecheck_return(method_name, method_type, fun, value, errors, return_error:)
+          unless type_check(value.return_value, fun.return_type)
+            errors << return_error.new(klass: klass,
+                                       method_name: method_name,
+                                       method_type: method_type,
+                                       type: fun.return_type,
+                                       value: value.return_value)
+          end
+        end
+
+        def keyword?(value)
+          value.is_a?(Hash) && value.keys.all? {|key| key.is_a?(Symbol) }
+        end
+
+        def zip_keyword_args(hash, fun)
+          fun.required_keywords.each do |name, param|
+            if hash.key?(name)
+              yield(hash[name], param)
+            else
+              return false
+            end
+          end
+
+          fun.optional_keywords.each do |name, param|
+            if hash.key?(name)
+              yield(hash[name], param)
+            end
+          end
+
+          hash.each do |name, value|
+            next if fun.required_keywords.key?(name)
+            next if fun.optional_keywords.key?(name)
+
+            if fun.rest_keywords
+              yield value, fun.rest_keywords
+            else
+              return false
+            end
+          end
+
+          true
+        end
+
+        def block_args(fun)
+          fun.update(
+               required_positionals: [],
+               trailing_positionals: [],
+               optional_positionals: fun.required_positionals + fun.optional_positionals,
+               rest_positionals:
+                 if fun.rest_positionals
+                   unless fun.trailing_positionals.empty?
+                     types = [
+                       fun.rest_positionals,
+                       *fun.trailing_positionals,
+                     ].compact
+                     Types::Union.new(types: types, location: nil)
+                   else
+                     fun.rest_positionals
+                   end
+                 else
+                   Types::Function::Param.new(name: nil, type: Types::Bases::Any.new(location: nil))
+                 end)
+        end
+
+        def zip_args(args, fun, &block)
+          case
+          when args.empty?
+            if fun.required_positionals.empty? && fun.trailing_positionals.empty? && fun.required_keywords.empty?
+              true
+            else
+              false
+            end
+          when !fun.required_positionals.empty?
+            yield_self do
+              param, fun_ = fun.drop_head
+              yield(args.first, param)
+              zip_args(args.drop(1), fun_, &block)
+            end
+          when fun.has_keyword?
+            yield_self do
+              hash = args.last
+              if keyword?(hash)
+                zip_keyword_args(hash, fun, &block) &&
+                  zip_args(args.take(args.size - 1),
+                           fun.update(required_keywords: {}, optional_keywords: {}, rest_keywords: nil),
+                           &block)
+              else
+                fun.required_keywords.empty? &&
+                  zip_args(args,
+                           fun.update(required_keywords: {}, optional_keywords: {}, rest_keywords: nil),
+                           &block)
+              end
+            end
+          when !fun.trailing_positionals.empty?
+            yield_self do
+              param, fun_ = fun.drop_tail
+              yield(args.last, param)
+              zip_args(args.take(args.size - 1), fun_, &block)
+            end
+          when !fun.optional_positionals.empty?
+            yield_self do
+              param, fun_ = fun.drop_head
+              yield(args.first, param)
+              zip_args(args.drop(1), fun_, &block)
+            end
+          when fun.rest_positionals
+            yield_self do
+              yield(args.first, fun.rest_positionals)
+              zip_args(args.drop(1), fun, &block)
+            end
+          else
+            false
+          end
+        end
+
+        def type_check(value, type)
+          case type
+          when Types::Bases::Any
+            true
+          when Types::Bases::Bool
+            true
+          when Types::Bases::Top
+            true
+          when Types::Bases::Bottom
+            false
+          when Types::Bases::Void
+            true
+          when Types::Bases::Self
+            call(value, IS_AP, klass)
+          when Types::Bases::Nil
+            call(value, IS_AP, NilClass)
+          when Types::Bases::Class
+            call(value, IS_AP, Class)
+          when Types::Bases::Instance
+            call(value, IS_AP, klass)
+          when Types::ClassInstance
+            call(value, IS_AP, Object.const_get(type.name.to_s))
+          when Types::ClassSingleton
+            klass = Object.const_get(type.name.to_s)
+            value == klass
+          when Types::Interface, Types::Variable
+            true
+          when Types::Literal
+            value == type.literal
+          when Types::Union
+            type.types.any? {|type| type_check(value, type) }
+          when Types::Intersection
+            type.types.all? {|type| type_check(value, type) }
+          when Types::Optional
+            call(value, IS_AP, NilClass) || type_check(value, type.type)
+          when Types::Alias
+            type_check(value, env.find_alias(type.name).type)
+          when Types::Tuple
+            call(value, IS_AP, ::Array) &&
+              type.types.map.with_index {|ty, index| type_check(value[index], ty) }
+          when Types::Record
+            call(value, IS_AP, ::Hash)
+          when Types::Proc
+            call(value, IS_AP, ::Proc)
+          else
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby/signature/test/setup.rb
+++ b/lib/ruby/signature/test/setup.rb
@@ -1,0 +1,56 @@
+require "ruby/signature"
+require "ruby/signature/test"
+
+require "optparse"
+require "shellwords"
+
+logger = Logger.new(STDERR)
+
+begin
+  opts = Shellwords.shellsplit(ENV["RBS_TEST_OPT"] || "-I sig")
+  filter = ENV.fetch("RBS_TEST_TARGET").split(",")
+  skips = (ENV["RBS_TEST_SKIP"] || "").split(",")
+  logger.level = (ENV["RBS_TEST_LOGLEVEL"] || "info")
+rescue
+  STDERR.puts "ruby/signature/test/setup handles the following environment variables:"
+  STDERR.puts "  [REQUIRED] RBS_TEST_TARGET: test target class name, `Foo::Bar,Foo::Baz` for each class or `Foo::*` for all classes under `Foo`"
+  STDERR.puts "  [OPTIONAL] RBS_TEST_SKIP: skip testing classes"
+  STDERR.puts "  [OPTIONAL] RBS_TEST_OPT: options for signatures (`-r` for libraries or `-I` for signatures)"
+  STDERR.puts "  [OPTIONAL] RBS_TEST_LOGLEVEL: one of debug|info|warn|error|fatal (defaults to info)"
+  exit 1
+end
+
+hooks = []
+
+env = Ruby::Signature::Environment.new
+
+loader = Ruby::Signature::EnvironmentLoader.new
+OptionParser.new do |opts|
+  opts.on("-r [LIB]") do |name| loader.add(library: name) end
+  opts.on("-I [DIR]") do |dir| loader.add(path: Pathname(dir)) end
+end.parse!(opts)
+loader.load(env: env)
+
+def match(filter, name)
+  if filter.end_with?("*")
+    name.start_with?(filter[0, filter.size - 1]) || name == filter[0, filter.size-3]
+  else
+    filter == name
+  end
+end
+
+TracePoint.trace :end do |tp|
+  class_name = tp.self.name
+
+  if class_name
+    if filter.any? {|f| match(f, class_name) } && skips.none? {|f| match(f, class_name) }
+      type_name = Ruby::Signature::Namespace.parse(class_name).absolute!.to_type_name
+      if hooks.none? {|hook| hook.klass == tp.self }
+        if env.find_class(type_name)
+          logger.info "Setting up a hook for #{class_name}"
+          hooks << Ruby::Signature::Test::Hook.install(env, tp.self, logger: logger).verify_all
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby/signature/types.rb
+++ b/lib/ruby/signature/types.rb
@@ -789,6 +789,39 @@ module Ruby
         def return_to_s
           return_type.to_s(1)
         end
+
+        def drop_head
+          case
+          when !required_positionals.empty?
+            [
+              required_positionals[0],
+              update(required_positionals: required_positionals.drop(1))
+            ]
+          when !optional_positionals.empty?
+            [
+              optional_positionals[0],
+              update(optional_positionals: optional_positionals.drop(1))
+            ]
+          else
+            raise "Cannot #drop_head"
+          end
+        end
+
+        def drop_tail
+          case
+          when !trailing_positionals.empty?
+            [
+              trailing_positionals.last,
+              update(trailing_positionals: trailing_positionals.take(trailing_positionals.size - 1))
+            ]
+          else
+            raise "Cannot #drop_tail"
+          end
+        end
+
+        def has_keyword?
+          !required_keywords.empty? || !optional_keywords.empty? || rest_keywords
+        end
       end
 
       class Proc

--- a/stdlib/builtin/string.rbs
+++ b/stdlib/builtin/string.rbs
@@ -290,7 +290,7 @@ class String < Object
 
   def index: (Regexp | String arg0, ?Integer arg1) -> Integer?
 
-  def initialize: (?String str) -> void
+  def initialize: (?String str, ?encoding: Encoding | String, ?capacity: Integer) -> void
 
   def insert: (Integer arg0, String arg1) -> String
 

--- a/stdlib/builtin/string.rbs
+++ b/stdlib/builtin/string.rbs
@@ -24,6 +24,7 @@ class String < Object
 
   def ===: (any arg0) -> bool
 
+  %a{rbs:test:skip}
   def =~: (Object arg0) -> Integer?
 
   def []: (Integer arg0, ?Integer arg1) -> String?

--- a/test/assets/test1/hello.rb
+++ b/test/assets/test1/hello.rb
@@ -1,0 +1,55 @@
+require "minitest/autorun"
+
+module Kaigi
+  class Conference
+    attr_reader :talks
+
+    def initialize
+      @talks = []
+    end
+
+    def speakers
+      talks.flat_map(&:speakers)
+    end
+
+    def each_speaker(&block)
+      speakers.each(&block)
+      self
+    end
+  end
+
+  class Talk
+    attr_reader :title
+    attr_reader :speakers
+
+    def initialize(title:)
+      @title = title
+      @speakers = []
+    end
+  end
+
+  class Speaker
+    attr_reader :name
+    attr_reader :email
+
+    def initialize(name:, email:)
+      @name = name
+      @email = email
+    end
+  end
+end
+
+class Kaigi::ConferenceTest < Minitest::Test
+  def test_1
+    conference = Kaigi::Conference.new
+
+    talk = Kaigi::Talk.new(title: "An introduction to typed Ruby programming")
+    talk.speakers << Kaigi::Speaker.new(name: "Soutaro Matsumoto", email: :"matsumoto@soutaro.com")
+
+    conference.talks << talk
+
+    conference.speakers {}
+
+    assert_equal ["Soutaro Matsumoto"], conference.speakers.map(&:name)
+  end
+end

--- a/test/assets/test1/hello.rbs
+++ b/test/assets/test1/hello.rbs
@@ -1,0 +1,22 @@
+class Kaigi::Conference
+  attr_reader talks: Array[Talk]
+
+  def initialize: () -> void
+  def speakers: -> Array[Speaker]
+
+  def each_speaker: () { (Speaker speaker) -> void } -> self
+end
+
+class Kaigi::Talk
+  attr_reader title: String
+  attr_reader speakers: Array[Speaker]
+
+  def initialize: (title: String title) -> void
+end
+
+class Kaigi::Speaker
+  attr_reader name: String
+  attr_reader email: String
+
+  def initialize: (name: String name, email: String email) -> void
+end

--- a/test/ruby/signature/test_test.rb
+++ b/test/ruby/signature/test_test.rb
@@ -1,0 +1,294 @@
+require "test_helper"
+
+require "ruby/signature/test"
+require "logger"
+
+class Ruby::Signature::TestTest < Minitest::Test
+  include TestHelper
+
+  Test = Ruby::Signature::Test
+
+  def io
+    @io ||= StringIO.new
+  end
+
+  def logger
+    @logger = Logger.new(io)
+  end
+
+  def test_verify_instance_method
+    SignatureManager.new do |manager|
+      manager.files[Pathname("foo.rbs")] = <<EOF
+module X
+end
+
+class Foo
+  extend X
+end
+
+module Y[A]
+end
+
+class Bar[X]
+  include Y[X]
+end
+EOF
+      manager.build do |env|
+        klass = Class.new do
+          def foo(*args)
+            if block_given?
+              (yield 123).to_s
+            else
+              :foo
+            end
+          end
+
+          def self.name
+            "Foo"
+          end
+        end
+
+        hook = Ruby::Signature::Test::Hook.new(env, klass, logger: logger)
+                 .verify(instance_method: :foo,
+                         types: ["(::String x, ::Integer i, foo: 123 foo) { (Integer) -> Array[Integer] } -> ::String"])
+
+        hook.run do
+          instance = klass.new
+          instance.foo { 1+2 }
+          instance.foo("", 3, foo: 234) {}
+          instance.foo
+        end
+
+        puts io.string
+      end
+    end
+  end
+
+  def test_verify_singleton_method
+    SignatureManager.new do |manager|
+      manager.files[Pathname("foo.rbs")] = <<EOF
+class Foo
+  def self.open: () { (Foo) -> void } -> Foo
+end
+EOF
+      manager.build do |env|
+        klass = Class.new do
+          def self.open(&block)
+            x = new
+            instance_exec x, &block
+            x
+          end
+
+          def self.name
+            "Foo"
+          end
+        end
+
+        hook = Ruby::Signature::Test::Hook.new(env, klass, logger: logger)
+                 .verify(singleton_method: :open,
+                         types: ["() { (::String) -> void } -> ::String"])
+
+        hook.run do
+          foo = klass.open {|foo|
+            1 + 2 + 3
+          }
+        end
+
+        refute_empty hook.errors
+        puts io.string
+      end
+    end
+  end
+
+  def test_verify_all
+    SignatureManager.new do |manager|
+      manager.files[Pathname("foo.rbs")] = <<EOF
+class Foo
+  def self.open: () { (String) -> void } -> Integer
+  def foo: (*any) -> String
+end
+EOF
+      manager.build do |env|
+        klass = Class.new do
+          def self.open(&block)
+            x = new
+            x.instance_exec "", &block
+            1
+          end
+
+          def foo(*args)
+            "hello foo"
+          end
+
+          def self.name
+            "Foo"
+          end
+        end
+
+        hook = Ruby::Signature::Test::Hook.new(env, klass, logger: logger).verify_all
+
+        hook.run do
+          foo = klass.open {
+            1 + 2 + 3
+
+            self.foo(1, 2, 3)
+          }
+        end
+
+        puts io.string
+        assert_empty hook.errors
+      end
+    end
+  end
+
+  def test_type_check
+    SignatureManager.new do |manager|
+      manager.files[Pathname("foo.rbs")] = <<EOF
+type foo = String | Integer
+EOF
+      manager.build do |env|
+        hook = Ruby::Signature::Test::Hook.new(env, Object, logger: logger)
+
+        assert hook.type_check(3, parse_type("::foo"))
+        assert hook.type_check("3", parse_type("::foo"))
+        refute hook.type_check(:foo, parse_type("::foo"))
+
+        assert hook.type_check(Object, parse_type("singleton(::Object)"))
+        assert hook.type_check(Object, parse_type("::Class"))
+        refute hook.type_check(Object, parse_type("singleton(::String)"))
+      end
+    end
+  end
+
+  def test_typecheck_args
+    SignatureManager.new do |manager|
+      manager.files[Pathname("foo.rbs")] = <<EOF
+type foo = String | Integer
+EOF
+      manager.build do |env|
+        hook = Ruby::Signature::Test::Hook.new(env, Object, logger: logger)
+
+        parse_method_type("(Integer) -> String").tap do |method_type|
+          errors = []
+          hook.typecheck_args "#foo",
+                              method_type,
+                              method_type.type,
+                              Test::Hook::ArgsReturn.new(arguments: [1], return_value: "1"),
+                              errors,
+                              type_error: Test::Hook::Errors::ArgumentTypeError,
+                              argument_error: Test::Hook::Errors::ArgumentError
+          assert_empty errors
+
+          errors = []
+          hook.typecheck_args "#foo",
+                              method_type,
+                              method_type.type,
+                              Test::Hook::ArgsReturn.new(arguments: ["1"], return_value: "1"),
+                              errors,
+                              type_error: Test::Hook::Errors::ArgumentTypeError,
+                              argument_error: Test::Hook::Errors::ArgumentError
+          assert errors.any? {|error| error.is_a?(Test::Hook::Errors::ArgumentTypeError) }
+
+          errors = []
+          hook.typecheck_args "#foo",
+                              method_type,
+                              method_type.type,
+                              Test::Hook::ArgsReturn.new(arguments: [1, 2], return_value: "1"),
+                              errors,
+                              type_error: Test::Hook::Errors::ArgumentTypeError,
+                              argument_error: Test::Hook::Errors::ArgumentError
+          assert errors.any? {|error| error.is_a?(Test::Hook::Errors::ArgumentError) }
+
+          errors = []
+          hook.typecheck_args "#foo",
+                              method_type,
+                              method_type.type,
+                              Test::Hook::ArgsReturn.new(arguments: [{ hello: :world }], return_value: "1"),
+                              errors,
+                              type_error: Test::Hook::Errors::ArgumentTypeError,
+                              argument_error: Test::Hook::Errors::ArgumentError
+          assert errors.any? {|error| error.is_a?(Test::Hook::Errors::ArgumentTypeError) }
+        end
+
+        parse_method_type("(foo: Integer, ?bar: String, **Symbol) -> String").tap do |method_type|
+          errors = []
+          hook.typecheck_args "#foo",
+                              method_type,
+                              method_type.type,
+                              Test::Hook::ArgsReturn.new(arguments: [{ foo: 31, baz: :baz }], return_value: "1"),
+                              errors,
+                              type_error: Test::Hook::Errors::ArgumentTypeError,
+                              argument_error: Test::Hook::Errors::ArgumentError
+          assert_empty errors
+
+          errors = []
+          hook.typecheck_args "#foo",
+                              method_type,
+                              method_type.type,
+                              Test::Hook::ArgsReturn.new(arguments: [{ foo: "foo" }], return_value: "1"),
+                              errors,
+                              type_error: Test::Hook::Errors::ArgumentTypeError,
+                              argument_error: Test::Hook::Errors::ArgumentError
+          assert errors.any? {|error| error.is_a?(Test::Hook::Errors::ArgumentTypeError) }
+
+          errors = []
+          hook.typecheck_args "#foo",
+                              method_type,
+                              method_type.type,
+                              Test::Hook::ArgsReturn.new(arguments: [{ bar: "bar" }], return_value: "1"),
+                              errors,
+                              type_error: Test::Hook::Errors::ArgumentTypeError,
+                              argument_error: Test::Hook::Errors::ArgumentError
+          assert errors.any? {|error| error.is_a?(Test::Hook::Errors::ArgumentError) }
+        end
+
+        parse_method_type("(?String, ?encoding: String) -> String").tap do |method_type|
+          errors = []
+          hook.typecheck_args "#foo",
+                              method_type,
+                              method_type.type,
+                              Test::Hook::ArgsReturn.new(arguments: [{ encoding: "ASCII-8BIT" }], return_value: "foo"),
+                              errors,
+                              type_error: Test::Hook::Errors::ArgumentTypeError,
+                              argument_error: Test::Hook::Errors::ArgumentError
+          assert_empty errors
+        end
+
+        parse_method_type("(parent: any, type: any) -> any").tap do |method_type|
+          errors = []
+          hook.typecheck_args "#foo",
+                              method_type,
+                              method_type.type,
+                              Test::Hook::ArgsReturn.new(arguments: [{ parent: nil, type: nil }], return_value: nil),
+                              errors,
+                              type_error: Test::Hook::Errors::ArgumentTypeError,
+                              argument_error: Test::Hook::Errors::ArgumentError
+          assert_empty errors.map {|e| Test::Hook::Errors.to_string(e) }
+        end
+
+        parse_method_type("() { (Integer) -> void } -> void").tap do |method_type|
+          errors = []
+
+          hook.typecheck_args "#foo",
+                              method_type,
+                              hook.block_args(method_type.block.type),
+                              Test::Hook::ArgsReturn.new(arguments: [], return_value: nil),
+                              errors,
+                              type_error: Test::Hook::Errors::BlockArgumentTypeError,
+                              argument_error: Test::Hook::Errors::BlockArgumentError
+          assert_empty errors.map {|e| Test::Hook::Errors.to_string(e) }
+
+          errors.clear
+          hook.typecheck_args "#foo",
+                              method_type,
+                              hook.block_args(method_type.block.type),
+                              Test::Hook::ArgsReturn.new(arguments: [1,2], return_value: nil),
+                              errors,
+                              type_error: Test::Hook::Errors::BlockArgumentTypeError,
+                              argument_error: Test::Hook::Errors::BlockArgumentError
+          assert_empty errors.map {|e| Test::Hook::Errors.to_string(e) }
+        end
+      end
+    end
+  end
+end

--- a/test/stdlib/Hash_test.rb
+++ b/test/stdlib/Hash_test.rb
@@ -1,0 +1,20 @@
+class HashTest < StdlibTest
+  target Hash
+  using hook.refinement
+
+  def test_each
+    h = { a: 123 }
+
+    h.each do |k, v|
+      # nop
+    end
+
+    h.each do |x|
+      # nop
+    end
+
+    h.each.each do |x, y|
+      #
+    end
+  end
+end

--- a/test/stdlib/String_test.rb
+++ b/test/stdlib/String_test.rb
@@ -1,0 +1,43 @@
+class StringTest < StdlibTest
+  target String
+  using hook.refinement
+
+  def test_gsub
+    s = "string"
+    s.gsub(/./, "")
+    s.gsub("a", "b")
+    s.gsub(/./) {|x| "" }
+    s.gsub(/./, {"foo" => "bar"})
+    s.gsub(/./)
+    s.gsub("")
+  end
+
+  def test_bytesize
+    s = "string"
+    s.bytesize
+  end
+
+  def test_endwith
+    s = "string"
+    s.end_with?
+    s.end_with?("foo")
+  end
+
+  def test_force_encoding
+    s = ""
+    s.force_encoding "ASCII-8BIT"
+    s.force_encoding Encoding::ASCII_8BIT
+  end
+
+  def test_include
+    "".include?("")
+  end
+
+  def test_initialize
+    String.new
+    String.new("")
+    String.new("", encoding: Encoding::ASCII_8BIT)
+    String.new("", encoding: Encoding::ASCII_8BIT, capacity: 123)
+    String.new(encoding: Encoding::ASCII_8BIT, capacity: 123)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,10 @@ module TestHelper
     Ruby::Signature::Parser.parse_type(string, variables: variables)
   end
 
+  def parse_method_type(string, variables: Set.new)
+    Ruby::Signature::Parser.parse_method_type(string, variables: variables)
+  end
+
   def type_name(string)
     Ruby::Signature::Namespace.parse(string).yield_self do |namespace|
       last = namespace.path.last


### PR DESCRIPTION
This PR adds runtime test feature for RBS signatures, which validates all method calls of given classes and checks if the arguments and return values `#is_a?` specified types.

We assume you run the runtime test with tests or specs:

```
$ RUBYOPT=-rruby/signature/test/setup RBS_TEST_TARGET="Kaigi::*" bundle exec rake test
```

### Discussions

* Generic types? => no test on generic parameters yet!
* Interface types? => no test yet! (I think using `#respond_to?` would make some sense.)
* Parametric polymorphism => no test yet! (We would be able to implement type inference, but not yet.)