### PR TITLE
Fix warning

### DIFF
--- a/lib/ruby/signature/scaffold/rbi.rb
+++ b/lib/ruby/signature/scaffold/rbi.rb
@@ -318,7 +318,7 @@ module Ruby
           rest_keywords = nil
 
           var_names = args_node.children[0]
-          pre_num, pre_init, opt, first_post, post_num, post_init, rest, kw, kwrest, block = args_node.children[1].children
+          pre_num, _pre_init, opt, _first_post, post_num, _post_init, rest, kw, kwrest, block = args_node.children[1].children
 
           pre_num.times.each do |i|
             name = var_names[i]

--- a/lib/ruby/signature/test/hook.rb
+++ b/lib/ruby/signature/test/hook.rb
@@ -210,7 +210,7 @@ module Ruby
 
             if errorss.none?(&:empty?)
               if (best_errors = hook.find_best_errors(errorss))
-                new_errors.push *best_errors
+                new_errors.push(*best_errors)
               else
                 new_errors << Errors::UnresolvedOverloadingError.new(
                   klass: hook.klass,
@@ -224,7 +224,7 @@ module Ruby
               hook.logger.error Errors.to_string(error)
             end
 
-            hook.errors.push *new_errors
+            hook.errors.push(*new_errors)
             result
           end
         end
@@ -311,8 +311,8 @@ module Ruby
         end
 
         def disable
-          self.instance_module.remove_method *instance_methods
-          self.singleton_module.remove_method *singleton_methods
+          self.instance_module.remove_method(*instance_methods)
+          self.singleton_module.remove_method(*singleton_methods)
           self
         end
 

--- a/ruby-signature.gemspec
+++ b/ruby-signature.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "racc", "~> 1.4.15"
   spec.add_development_dependency "minitest-reporters", "~> 1.3.6"

--- a/test/ruby/signature/rbi_scaffold_test.rb
+++ b/test/ruby/signature/rbi_scaffold_test.rb
@@ -30,9 +30,10 @@ end
 
     parser.parse(rbi)
 
-    decls = parser.decls
+    parser.decls
 
-    # pp decls
+    # decls = parser.decls
+    # pp parser.decls
   end
 
   def assert_write(decls, string)

--- a/test/ruby/signature/test_test.rb
+++ b/test/ruby/signature/test_test.rb
@@ -133,7 +133,7 @@ EOF
 
         hook.run do
           _foo = klass.open {
-            1 + 2 + 3
+            _bar = 1 + 2 + 3
 
             self.foo(1, 2, 3)
           }

--- a/test/ruby/signature/test_test.rb
+++ b/test/ruby/signature/test_test.rb
@@ -91,7 +91,7 @@ EOF
                          types: ["() { (::String) -> void } -> ::String"])
 
         hook.run do
-          foo = klass.open {|foo|
+          _foo = klass.open {|foo|
             1 + 2 + 3
           }
         end
@@ -132,7 +132,7 @@ EOF
         hook = Ruby::Signature::Test::Hook.install(env, klass, logger: logger).verify_all
 
         hook.run do
-          foo = klass.open {
+          _foo = klass.open {
             1 + 2 + 3
 
             self.foo(1, 2, 3)


### PR DESCRIPTION
I use following ruby.

```
% ruby -v
ruby 2.7.0dev (2019-10-16T12:00:36Z master f8fb51c976) [x86_64-darwin19]
```

I got warnings like following:

```
% bundle exec ruby -v bin/test_runner.rb 2>&1 | grep 'warning: '                 
/Users/sei/src/github.com/ruby/ruby-signature/lib/ruby/signature/scaffold/rbi.rb:321: warning: assigned but unused variable - pre_init
/Users/sei/src/github.com/ruby/ruby-signature/lib/ruby/signature/scaffold/rbi.rb:321: warning: assigned but unused variable - first_post
/Users/sei/src/github.com/ruby/ruby-signature/lib/ruby/signature/scaffold/rbi.rb:321: warning: assigned but unused variable - post_init
/Users/sei/src/github.com/ruby/ruby-signature/lib/ruby/signature/parser.rb:2811: warning: mismatched indentations at 'end' with 'module' at 9
/Users/sei/src/github.com/ruby/ruby-signature/lib/ruby/signature/parser.rb:2812: warning: mismatched indentations at 'end' with 'module' at 8
/Users/sei/src/github.com/ruby/ruby-signature/lib/ruby/signature/test/hook.rb:213: warning: `*' interpreted as argument prefix
/Users/sei/src/github.com/ruby/ruby-signature/lib/ruby/signature/test/hook.rb:227: warning: `*' interpreted as argument prefix
/Users/sei/src/github.com/ruby/ruby-signature/lib/ruby/signature/test/hook.rb:314: warning: `*' interpreted as argument prefix
/Users/sei/src/github.com/ruby/ruby-signature/lib/ruby/signature/test/hook.rb:315: warning: `*' interpreted as argument prefix
...../Users/sei/src/github.com/ruby/ruby-signature/lib/ruby/signature/test/hook.rb:196: warning: The last argument is used as the keyword parameter
/Users/sei/src/github.com/ruby/ruby-signature/lib/ruby/signature/test/hook.rb:196: warning: The last argument is used as the keyword parameter
/Users/sei/src/github.com/ruby/ruby-signature/lib/ruby/signature/test/hook.rb:196: warning: The last argument is used as the keyword parameter
```

after merging this pull request:

```
% bundle exec ruby -v bin/test_runner.rb 2>&1 | grep 'warning: '
/Users/sei/src/github.com/ruby/ruby-signature/lib/ruby/signature/parser.rb:2811: warning: mismatched indentations at 'end' with 'module' at 9
/Users/sei/src/github.com/ruby/ruby-signature/lib/ruby/signature/parser.rb:2812: warning: mismatched indentations at 'end' with 'module' at 8
```
