### PR TITLE
Add generics variance syntax

### DIFF
--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -402,13 +402,13 @@ _decl_ ::= _class-decl_                         # Class declaration
          | _const-decl_                         # Constant declaration
          | _global-decl_                        # Global declaration
 
-_class-decl_ ::= `class` _class-name_ _type-parameters_ _members_ `end`
-               | `class` _class-name_ _type-parameters_ `<` _class-name_ _type-arguments_ _members_ `end`
+_class-decl_ ::= `class` _class-name_ _module-type-parameters_ _members_ `end`
+               | `class` _class-name_ _module-type-parameters_ `<` _class-name_ _type-arguments_ _members_ `end`
  
-_module-decl_ ::= `module` _module-name_ _type-parameters_ _members_ `end`
-                | `module` _module-name_ _type-parameters_ `:` _class-name_ _type-arguments_ _members_ `end`
+_module-decl_ ::= `module` _module-name_ _module-type-parameters_ _members_ `end`
+                | `module` _module-name_ _module-type-parameters_ `:` _class-name_ _type-arguments_ _members_ `end`
 
-_interface-decl_ ::= `interface` _interface-name_ _type-parameters_ _interface-members_ `end`
+_interface-decl_ ::= `interface` _interface-name_ _module-type-parameters_ _interface-members_ `end`
 
 _interface-members_ ::= _method-member_              # Method 
                       | _include-member_             # Mixin (include)
@@ -424,6 +424,12 @@ _global-decl_ ::= _global-name_ `:` _type_
 
 _const-name_ ::= _namespace_ /[A-Z]\w*/
 _global-name_ ::= /$[a-zA-Z]\w+/ | ...
+
+_module-type-parameters_ ::=                                                  # Empty
+                           | `[` _module-type-parameter_ `,` ... `]`
+
+_module-type-parameter_ ::= _variance_ _type-variable_
+_variance_ ::= `out` | `in`
 ```
 
 ### Class declaration

--- a/lib/ruby/signature/ast/declarations.rb
+++ b/lib/ruby/signature/ast/declarations.rb
@@ -2,6 +2,59 @@ module Ruby
   module Signature
     module AST
       module Declarations
+        class ModuleTypeParams
+          attr_reader :params
+
+          TypeParam = Struct.new(:name, :variance, :skip_validation, keyword_init: true)
+
+          def initialize()
+            @params = []
+          end
+
+          def add(param)
+            params << param
+            self
+          end
+
+          def ==(other)
+            other.is_a?(ModuleTypeParams) && other.params == params
+          end
+
+          def [](name)
+            params.find {|p| p.name == name }
+          end
+
+          def to_json(*a)
+            {
+              params: params
+            }.to_json(*a)
+          end
+
+          def each(&block)
+            params.each(&block)
+          end
+
+          def self.empty
+            new
+          end
+
+          def variance(name)
+            self[name].variance
+          end
+
+          def skip_validation?(name)
+            self[name].skip_validation
+          end
+
+          def empty?
+            params.empty?
+          end
+
+          def size
+            params.size
+          end
+        end
+
         class Class
           class Super
             attr_reader :name

--- a/lib/ruby/signature/cli.rb
+++ b/lib/ruby/signature/cli.rb
@@ -144,9 +144,9 @@ module Ruby
         if env.class?(type_name)
           ancestor = case kind
                      when :instance
-                       definition = env.find_class(type_name)
+                       decl = env.find_class(type_name)
                        Definition::Ancestor::Instance.new(name: type_name,
-                                                          args: Types::Variable.build(definition.type_params))
+                                                          args: Types::Variable.build(decl.type_params.each.map(&:name)))
                      when :singleton
                        Definition::Ancestor::Singleton.new(name: type_name)
                      end

--- a/lib/ruby/signature/definition.rb
+++ b/lib/ruby/signature/definition.rb
@@ -129,6 +129,15 @@ module Ruby
         @self_type.args.map(&:name)
       end
 
+      def type_params_decl
+        case declaration
+        when AST::Declarations::Extension
+          nil
+        else
+          declaration.type_params
+        end
+      end
+
       def each_type(&block)
         if block_given?
           methods.each_value do |method|

--- a/lib/ruby/signature/errors.rb
+++ b/lib/ruby/signature/errors.rb
@@ -11,7 +11,7 @@ module Ruby
         @args = args
         @params = params
         @location = location
-        super "#{Location.to_string location}: #{type_name} expects parameters [#{params.join(", ")}], but given args [#{args.join(", ")}]"
+        super "#{Location.to_string location}: #{type_name} expects parameters [#{params.each.map(&:name).join(", ")}], but given args [#{args.join(", ")}]"
       end
 
       def self.check!(type_name:, args:, params:, location:)

--- a/lib/ruby/signature/types.rb
+++ b/lib/ruby/signature/types.rb
@@ -126,6 +126,8 @@ module Ruby
             new(name: v, location: nil)
           when Array
             v.map {|x| new(name: x, location: nil) }
+          else
+            raise
           end
         end
 

--- a/lib/ruby/signature/writer.rb
+++ b/lib/ruby/signature/writer.rb
@@ -54,7 +54,7 @@ module Ruby
                         end
           write_comment decl.comment, level: 0
           write_annotation decl.annotations, level: 0
-          out.puts "class #{name_and_args(decl.name, decl.type_params)}#{super_class}"
+          out.puts "class #{name_and_params(decl.name, decl.type_params)}#{super_class}"
 
           decl.members.each.with_index do |member, index|
             if index > 0
@@ -72,7 +72,7 @@ module Ruby
 
           write_comment decl.comment, level: 0
           write_annotation decl.annotations, level: 0
-          out.puts "module #{name_and_args(decl.name, decl.type_params)}#{self_type}"
+          out.puts "module #{name_and_params(decl.name, decl.type_params)}#{self_type}"
           decl.members.each.with_index do |member, index|
             if index > 0
               out.puts
@@ -96,7 +96,7 @@ module Ruby
         when AST::Declarations::Interface
           write_comment decl.comment, level: 0
           write_annotation decl.annotations, level: 0
-          out.puts "interface #{name_and_args(decl.name, decl.type_params)}"
+          out.puts "interface #{name_and_params(decl.name, decl.type_params)}"
           decl.members.each.with_index do |member, index|
             if index > 0
               out.puts
@@ -116,6 +116,30 @@ module Ruby
             write_member member
           end
           out.puts "end"
+        end
+      end
+
+      def name_and_params(name, params)
+        if params.empty?
+          "#{name}"
+        else
+          ps = params.each.map do |param|
+            s = ""
+            if param.skip_validation
+              s << "unchecked "
+            end
+            case param.variance
+            when :invariant
+              # nop
+            when :covariant
+              s << "out "
+            when :contravariant
+              s << "in "
+            end
+            s + param.name.to_s
+          end
+
+          "#{name}[#{ps.join(", ")}]"
         end
       end
 

--- a/test/ruby/signature/rbi_scaffold_test.rb
+++ b/test/ruby/signature/rbi_scaffold_test.rb
@@ -307,7 +307,7 @@ end
     EOF
 
     assert_write parser.decls, <<-EOF
-class Array[Elem]
+class Array[out Elem]
   include Enumerable
 end
     EOF
@@ -405,6 +405,28 @@ end
 
     assert_write parser.decls, <<-EOF
 class Dir
+  include Enumerable
+end
+    EOF
+  end
+
+  def test_parameter_type_member_variance
+    parser = RBI.new
+
+    parser.parse <<-EOF
+class Dir
+  extend T::Generic
+
+  X = type_member(:out)
+  Y = type_member(:in)
+  Z = type_member()
+
+  include Enumerable
+end
+    EOF
+
+    assert_write parser.decls, <<-EOF
+class Dir[out X, in Y, Z]
   include Enumerable
 end
     EOF

--- a/test/ruby/signature/writer_test.rb
+++ b/test/ruby/signature/writer_test.rb
@@ -129,4 +129,11 @@ class Bar
 end
     SIG
   end
+
+  def test_variance
+    assert_writer <<-SIG
+class Foo[out A, unchecked B, in C] < Bar[A, C, B]
+end
+    SIG
+  end
 end


### PR DESCRIPTION
This proposes to support specifying _variance_ of class/module/interface generic members.

```
class ReadOnlyArray[out A]
  def []: (Integer) -> A
end
```

We use `out` for co-variant,  `in` for contra-variant, ` ` (empty) for in-variant.

The parser also implements `unchecked` attribute so that we can make array co-variant.

```
class Array[unchecked out Elem]
  ...
end
```