### PR TITLE
any out, untyped in

### DIFF
--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -19,7 +19,7 @@ _type_ ::= _class-name_ _type-arguments_                (Class instance type)
          | `instance`
          | `class`
          | `bool`
-         | `any`
+         | `untyped`
          | `nil`
          | `top`
          | `bot`
@@ -179,7 +179,7 @@ Proc type denots type of procedures, `Proc` instances.
 
 `bool` is an abstract type for truth value.
 
-`any` is for _a type without type checking_. It is `?` in gradual typing, _dynamic_ in some other languages. Subtype _and_ supertype of all of the types.
+`untyped` is for _a type without type checking_. It is `?` in gradual typing, _dynamic_ in some languages like C#, and _any_ in TypeScript. It is both subtype _and_ supertype of all of the types. (The type was `any` but renamed to `untyped`.)
 
 `nil` is for _nil_.
 

--- a/lib/ruby/signature/parser.y
+++ b/lib/ruby/signature/parser.y
@@ -4,7 +4,7 @@ class Ruby::Signature::Parser
         tANNOTATION
         tSTRING tSYMBOL tINTEGER tWRITE_ATTR
         kLPAREN kRPAREN kLBRACKET kRBRACKET kLBRACE kRBRACE
-        kVOID kNIL kANY kTOP kBOT kSELF kSELFQ kINSTANCE kCLASS kBOOL kSINGLETON kTYPE kDEF kMODULE kSUPER
+        kVOID kNIL kANY kUNTYPED kTOP kBOT kSELF kSELFQ kINSTANCE kCLASS kBOOL kSINGLETON kTYPE kDEF kMODULE kSUPER
         kPRIVATE kPUBLIC kALIAS
         kCOLON kCOLON2 kCOMMA kBAR kAMP kHAT kARROW kQUESTION kEXCLAMATION kSTAR kSTAR2 kFATARROW kEQ kDOT kLT
         kINTERFACE kEND kINCLUDE kEXTEND kATTRREADER kATTRWRITER kATTRACCESSOR tOPERATOR tQUOTEDMETHOD
@@ -501,7 +501,7 @@ rule
   method_name0: tUIDENT | tLIDENT | identifier_keywords
 
   identifier_keywords:
-      kCLASS | kVOID | kNIL | kANY | kTOP | kBOT | kINSTANCE | kBOOL | kSINGLETON
+      kCLASS | kVOID | kNIL | kANY | kUNTYPED | kTOP | kBOT | kINSTANCE | kBOOL | kSINGLETON
     | kTYPE | kMODULE | kPRIVATE | kPUBLIC | kEND | kINCLUDE | kEXTEND | kPREPEND
     | kATTRREADER | kATTRACCESSOR | kATTRWRITER | kDEF | kEXTENSION | kSELF | kINCOMPATIBLE
 
@@ -611,6 +611,10 @@ rule
         result = Types::Bases::Void.new(location: val[0].location)
       }
     | kANY {
+        Ruby::Signature.logger.warn "`any` type is deprecated. Use `untyped` instead. (#{val[0].location.to_s})"
+        result = Types::Bases::Any.new(location: val[0].location)
+      }
+    | kUNTYPED {
         result = Types::Bases::Any.new(location: val[0].location)
       }
     | kBOOL {
@@ -1106,6 +1110,7 @@ KEYWORDS = {
   "self" => :kSELF,
   "void" => :kVOID,
   "any" => :kANY,
+  "untyped" => :kUNTYPED,
   "top" => :kTOP,
   "bot" => :kBOT,
   "instance" => :kINSTANCE,

--- a/lib/ruby/signature/types.rb
+++ b/lib/ruby/signature/types.rb
@@ -57,7 +57,7 @@ module Ruby
             when Types::Bases::Void
               'void'
             when Types::Bases::Any
-              'any'
+              'untyped'
             when Types::Bases::Nil
               'nil'
             when Types::Bases::Top

--- a/stdlib/builtin/array.rbs
+++ b/stdlib/builtin/array.rbs
@@ -327,10 +327,10 @@ class Array[Elem] < Object
   def *: (Integer arg0) -> ::Array[Elem]
        | (String arg0) -> String
 
-  def +: (::Enumerable[Elem, any] arg0) -> ::Array[Elem]
+  def +: (::Enumerable[Elem, untyped] arg0) -> ::Array[Elem]
        | (::Array[Elem] arg0) -> ::Array[Elem]
 
-  def -: (::Array[any] arg0) -> ::Array[Elem]
+  def -: (::Array[untyped] arg0) -> ::Array[Elem]
 
   def <<: (Elem arg0) -> ::Array[Elem]
 
@@ -359,7 +359,7 @@ class Array[Elem] < Object
   def collect: [U] () { (Elem arg0) -> U } -> ::Array[U]
              | () -> ::Enumerator[Elem, self]
 
-  def combination: (Integer arg0) { (::Array[Elem] arg0) -> any } -> ::Array[Elem]
+  def combination: (Integer arg0) { (::Array[Elem] arg0) -> untyped } -> ::Array[Elem]
                  | (Integer arg0) -> ::Enumerator[::Array[Elem], self]
 
   # This is implemented in C++ to fix the return type
@@ -369,7 +369,7 @@ class Array[Elem] < Object
   # [ "a", nil, "b", nil, "c", nil ].compact
   #                   #=> [ "a", "b", "c" ]
   # ```
-  def compact: () -> ::Array[any]
+  def compact: () -> ::Array[untyped]
 
   # Removes `nil` elements from the array.
   # 
@@ -399,9 +399,9 @@ class Array[Elem] < Object
   # ```
   def count: () -> Integer
            | (?Elem arg0) -> Integer
-           | () { (Elem arg0) -> any } -> Integer
+           | () { (Elem arg0) -> untyped } -> Integer
 
-  def cycle: (?Integer arg0) { (Elem arg0) -> any } -> any
+  def cycle: (?Integer arg0) { (Elem arg0) -> untyped } -> untyped
            | (?Integer arg0) -> ::Enumerator[Elem, self]
 
   def delete: (Elem arg0) -> Elem?
@@ -409,20 +409,20 @@ class Array[Elem] < Object
 
   def delete_at: (Integer arg0) -> Elem?
 
-  def delete_if: () { (Elem arg0) -> any } -> ::Array[Elem]
+  def delete_if: () { (Elem arg0) -> untyped } -> ::Array[Elem]
                | () -> ::Enumerator[Elem, self]
 
-  def difference: (*::Array[any] arrays) -> ::Array[Elem]
+  def difference: (*::Array[untyped] arrays) -> ::Array[Elem]
 
   def drop: (Integer arg0) -> ::Array[Elem]
 
-  def drop_while: () { (Elem arg0) -> any } -> ::Array[Elem]
+  def drop_while: () { (Elem arg0) -> untyped } -> ::Array[Elem]
                 | () -> ::Enumerator[Elem, self]
 
   def each: () -> ::Enumerator[Elem, self]
-          | () { (Elem arg0) -> any } -> ::Array[Elem]
+          | () { (Elem arg0) -> untyped } -> ::Array[Elem]
 
-  def each_index: () { (Integer arg0) -> any } -> ::Array[Elem]
+  def each_index: () { (Integer arg0) -> untyped } -> ::Array[Elem]
                 | () -> ::Enumerator[Elem, self]
 
   # Returns `true` if `self` contains no elements.
@@ -475,12 +475,12 @@ class Array[Elem] < Object
   # a = [ 1, 2, [3, [4, 5] ] ]
   # a.flatten(1)              #=> [1, 2, 3, [4, 5]]
   # ```
-  def flatten: (?Integer depth) -> ::Array[any]
+  def flatten: (?Integer depth) -> ::Array[untyped]
 
   def `include?`: [U] (U arg0) -> bool
 
   def index: [U] (?U arg0) -> Integer?
-           | () { (Elem arg0) -> any } -> Integer?
+           | () { (Elem arg0) -> untyped } -> Integer?
            | () -> ::Enumerator[Elem, self]
 
   def initialize: () -> Object
@@ -502,7 +502,7 @@ class Array[Elem] < Object
 
   def join: (?String arg0) -> String
 
-  def keep_if: () { (Elem arg0) -> any } -> ::Array[Elem]
+  def keep_if: () { (Elem arg0) -> untyped } -> ::Array[Elem]
 
   # Returns the last element(s) of `self` . If the array is empty, the first
   # form returns `nil` .
@@ -539,7 +539,7 @@ class Array[Elem] < Object
   def member?: (Elem arg0) -> bool
 
   def permutation: (?Integer arg0) -> ::Enumerator[::Array[Elem], self]
-                 | (?Integer arg0) { (::Array[Elem] arg0) -> any } -> ::Array[Elem]
+                 | (?Integer arg0) { (::Array[Elem] arg0) -> untyped } -> ::Array[Elem]
 
   def pop: (?Integer arg0) -> ::Array[Elem]
          | () -> Elem?
@@ -552,16 +552,16 @@ class Array[Elem] < Object
 
   def rassoc: [U] (U arg0) -> Elem?
 
-  def reject: () { (Elem arg0) -> any } -> ::Array[Elem]
+  def reject: () { (Elem arg0) -> untyped } -> ::Array[Elem]
             | () -> ::Enumerator[Elem, self]
 
-  def reject!: () { (Elem arg0) -> any } -> ::Array[Elem]
+  def reject!: () { (Elem arg0) -> untyped } -> ::Array[Elem]
              | () -> ::Enumerator[Elem, self]
 
-  def repeated_combination: (Integer arg0) { (::Array[Elem] arg0) -> any } -> ::Array[Elem]
+  def repeated_combination: (Integer arg0) { (::Array[Elem] arg0) -> untyped } -> ::Array[Elem]
                           | (Integer arg0) -> ::Enumerator[::Array[Elem], self]
 
-  def repeated_permutation: (Integer arg0) { (::Array[Elem] arg0) -> any } -> ::Array[Elem]
+  def repeated_permutation: (Integer arg0) { (::Array[Elem] arg0) -> untyped } -> ::Array[Elem]
                           | (Integer arg0) -> ::Enumerator[::Array[Elem], self]
 
   # Returns a new array containing `self` ‘s elements in reverse order.
@@ -581,11 +581,11 @@ class Array[Elem] < Object
   # ```
   def reverse!: () -> ::Array[Elem]
 
-  def reverse_each: () { (Elem arg0) -> any } -> ::Array[Elem]
+  def reverse_each: () { (Elem arg0) -> untyped } -> ::Array[Elem]
                   | () -> ::Enumerator[Elem, self]
 
   def rindex: (?Elem arg0) -> Integer?
-            | () { (Elem arg0) -> any } -> Integer?
+            | () { (Elem arg0) -> untyped } -> Integer?
             | () -> ::Enumerator[Elem, self]
 
   def rotate: (?Integer arg0) -> ::Array[Elem]
@@ -595,10 +595,10 @@ class Array[Elem] < Object
   def sample: () -> Elem?
             | (?Integer arg0) -> ::Array[Elem]
 
-  def select: () { (Elem arg0) -> any } -> ::Array[Elem]
+  def select: () { (Elem arg0) -> untyped } -> ::Array[Elem]
             | () -> ::Enumerator[Elem, self]
 
-  def select!: () { (Elem arg0) -> any } -> ::Array[Elem]
+  def select!: () { (Elem arg0) -> untyped } -> ::Array[Elem]
              | () -> ::Enumerator[Elem, self]
 
   # Removes the first element of `self` and returns it (shifting all other
@@ -709,7 +709,7 @@ class Array[Elem] < Object
 
   def take: (Integer arg0) -> ::Array[Elem]
 
-  def take_while: () { (Elem arg0) -> any } -> ::Array[Elem]
+  def take_while: () { (Elem arg0) -> untyped } -> ::Array[Elem]
                 | () -> ::Enumerator[Elem, self]
 
   # Returns `self` .
@@ -723,7 +723,7 @@ class Array[Elem] < Object
 
   def transpose: () -> ::Array[Elem]
 
-  def union: (*::Array[any] arrays) -> ::Array[any]
+  def union: (*::Array[untyped] arrays) -> ::Array[untyped]
 
   # Returns a new array by removing duplicate values in `self` .
   # 

--- a/stdlib/builtin/basic_object.rbs
+++ b/stdlib/builtin/basic_object.rbs
@@ -63,9 +63,9 @@ class BasicObject
   # Boolean negate.
   def !: () -> bool
 
-  def !=: (any other) -> bool
+  def !=: (untyped other) -> bool
 
-  def ==: (any other) -> bool
+  def ==: (untyped other) -> bool
 
   # Returns an integer identifier for `obj` .
   # 
@@ -86,14 +86,14 @@ class BasicObject
   # ```
   def __id__: () -> Integer
 
-  def __send__: (Symbol arg0, *any arg1) -> any
+  def __send__: (Symbol arg0, *untyped arg1) -> untyped
 
-  def equal?: (any other) -> bool
+  def equal?: (untyped other) -> bool
 
-  def instance_eval: (?String arg0, ?String filename, ?Integer lineno) -> any
+  def instance_eval: (?String arg0, ?String filename, ?Integer lineno) -> untyped
                    | [U] () { () -> U } -> U
 
-  def instance_exec: [U, V] (*V args) { (any args) -> U } -> U
+  def instance_exec: [U, V] (*V args) { (untyped args) -> U } -> U
 
   private
   def initialize: () -> void

--- a/stdlib/builtin/binding.rbs
+++ b/stdlib/builtin/binding.rbs
@@ -64,7 +64,7 @@ class Binding < Object
   # ```ruby
   # binding.eval("#{symbol}")
   # ```
-  def local_variable_get: (String | Symbol symbol) -> any
+  def local_variable_get: (String | Symbol symbol) -> untyped
 
   # Set local variable named `symbol` as `obj`.
   # 
@@ -90,7 +90,7 @@ class Binding < Object
   # ```
   # 
   # if `obj` can be dumped in Ruby code.
-  def local_variable_set: (String | Symbol symbol, any obj) -> any
+  def local_variable_set: (String | Symbol symbol, untyped obj) -> untyped
 
   # Returns the bound receiver of the binding object.
   def receiver: () -> Object

--- a/stdlib/builtin/class.rbs
+++ b/stdlib/builtin/class.rbs
@@ -80,7 +80,7 @@ class Class < Module
   # 
   # klass.allocate.initialized? #=> false
   # ```
-  def allocate: () -> any
+  def allocate: () -> untyped
 
   # Sorbet hijacks Class#new to re-use the sig from MyClass#initialize when creating new instances of a class.
   # This method must be here so that all calls to MyClass.new aren't forced to take 0 arguments.
@@ -88,9 +88,9 @@ class Class < Module
   # invokes that object’s `initialize` method, passing it *args* . This is
   # the method that ends up getting called whenever an object is constructed
   # using .new.
-  def new: (*any args) -> any
+  def new: (*untyped args) -> untyped
 
-  def inherited: (Class arg0) -> any
+  def inherited: (Class arg0) -> untyped
 
   def instance_methods: (?bool arg0) -> ::Array[Symbol]
 
@@ -117,6 +117,6 @@ class Class < Module
 
   def initialize: () -> void
                 | (?Class superclass) -> void
-                | () { (Class arg0) -> any } -> void
-                | (?Class superclass) { (Class arg0) -> any } -> void
+                | () { (Class arg0) -> untyped } -> void
+                | (?Class superclass) { (Class arg0) -> untyped } -> void
 end

--- a/stdlib/builtin/comparable.rbs
+++ b/stdlib/builtin/comparable.rbs
@@ -36,24 +36,24 @@
 module Comparable
   # Compares two objects based on the receiver’s `<=>` method, returning
   # true if it returns -1.
-  def <: (any other) -> bool
+  def <: (untyped other) -> bool
 
   # Compares two objects based on the receiver’s `<=>` method, returning
   # true if it returns -1 or 0.
-  def <=: (any other) -> bool
+  def <=: (untyped other) -> bool
 
   # Compares two objects based on the receiver’s `<=>` method, returning
   # true if it returns 0. Also returns true if *obj* and *other* are the
   # same object.
-  def ==: (any other) -> bool
+  def ==: (untyped other) -> bool
 
   # Compares two objects based on the receiver’s `<=>` method, returning
   # true if it returns 1.
-  def >: (any other) -> bool
+  def >: (untyped other) -> bool
 
   # Compares two objects based on the receiver’s `<=>` method, returning
   # true if it returns 0 or 1.
-  def >=: (any other) -> bool
+  def >=: (untyped other) -> bool
 
   # Returns `false` if *obj* `<=>` *min* is less than zero or if *anObject*
   # `<=>` *max* is greater than zero, `true` otherwise.
@@ -64,7 +64,7 @@ module Comparable
   # 'cat'.between?('ant', 'dog')   #=> true
   # 'gnu'.between?('ant', 'dog')   #=> false
   # ```
-  def between?: (any min, any max) -> bool
+  def between?: (untyped min, untyped max) -> bool
 
   # Returns *min* if *obj* `<=>` *min* is less than zero, *max* if *obj*
   # `<=>` *max* is greater than zero and *obj* otherwise.
@@ -77,5 +77,5 @@ module Comparable
   # 'd'.clamp('a', 'f')      #=> 'd'
   # 'z'.clamp('a', 'f')      #=> 'f'
   # ```
-  def clamp: (any min, any max) -> any
+  def clamp: (untyped min, untyped max) -> untyped
 end

--- a/stdlib/builtin/dir.rbs
+++ b/stdlib/builtin/dir.rbs
@@ -19,7 +19,7 @@ class Dir < Object
 
   def self.exist?: (String file) -> bool
 
-  def self.foreach: (String dir, ?Encoding arg0) { (String arg0) -> any } -> NilClass
+  def self.foreach: (String dir, ?Encoding arg0) { (String arg0) -> untyped } -> NilClass
                   | (String dir, ?Encoding arg0) -> ::Enumerator[String, self]
 
   # Returns the path to the current working directory of this process as a
@@ -33,7 +33,7 @@ class Dir < Object
   def self.getwd: () -> String
 
   def self.glob: (String | ::Array[String] pattern, ?Integer flags) -> ::Array[String]
-               | (String | ::Array[String] pattern, ?Integer flags) { (String arg0) -> any } -> NilClass
+               | (String | ::Array[String] pattern, ?Integer flags) { (String arg0) -> untyped } -> NilClass
 
   def self.home: (?String arg0) -> String
 
@@ -65,7 +65,7 @@ class Dir < Object
   # ```
   def close: () -> NilClass
 
-  def each: () { (String arg0) -> any } -> self
+  def each: () { (String arg0) -> untyped } -> self
           | () -> ::Enumerator[String, self]
 
   # Returns the file descriptor used in *dir* .
@@ -140,5 +140,5 @@ class Dir < Object
   def to_path: () -> String?
 
   def self.[]: (String | ::Array[String] pattern, ?Integer flags) -> ::Array[String]
-             | (String | ::Array[String] pattern, ?Integer flags) { (String arg0) -> any } -> NilClass
+             | (String | ::Array[String] pattern, ?Integer flags) { (String arg0) -> untyped } -> NilClass
 end

--- a/stdlib/builtin/encoding.rbs
+++ b/stdlib/builtin/encoding.rbs
@@ -6,7 +6,7 @@ class Encoding < Object
   #           "SJIS"=>"Shift_JIS", "eucJP"=>"EUC-JP", "CP932"=>"Windows-31J"}
   def self.aliases: () -> ::Hash[String, String]
 
-  def self.compatible?: (any obj1, any obj2) -> Encoding?
+  def self.compatible?: (untyped obj1, untyped obj2) -> Encoding?
 
   # Returns default external encoding.
   # 

--- a/stdlib/builtin/enumerable.rbs
+++ b/stdlib/builtin/enumerable.rbs
@@ -22,7 +22,7 @@ module Enumerable[Elem, Return]: _Each[Elem, Return]
   #     [nil, true, 99].all?                              #=> false
   #     [].all?                                           #=> true
   def all?: () -> bool
-          | () { (Elem arg0) -> any } -> bool
+          | () { (Elem arg0) -> untyped } -> bool
 
   # Passes each element of the collection to the given block. The method
   # returns `true` if the block ever returns a value other than `false` or
@@ -43,12 +43,12 @@ module Enumerable[Elem, Return]: _Each[Elem, Return]
   # [].any?                                           #=> false
   # ```
   def `any?`: () -> bool
-            | () { (Elem arg0) -> any } -> bool
+            | () { (Elem arg0) -> untyped } -> bool
 
   def collect: [U] () { (Elem arg0) -> U } -> ::Array[U]
              | () -> ::Enumerator[Elem, Return]
 
-  def collect_concat: [U] () { (Elem arg0) -> ::Enumerator[U, any] } -> ::Array[U]
+  def collect_concat: [U] () { (Elem arg0) -> ::Enumerator[U, untyped] } -> ::Array[U]
 
   # Returns the number of items in `enum` through enumeration. If an
   # argument is given, the number of items in `enum` that are equal to
@@ -62,27 +62,27 @@ module Enumerable[Elem, Return]: _Each[Elem, Return]
   # ary.count{ |x| x%2==0 } #=> 3
   # ```
   def count: () -> Integer
-           | (?any arg0) -> Integer
-           | () { (Elem arg0) -> any } -> Integer
+           | (?untyped arg0) -> Integer
+           | () { (Elem arg0) -> untyped } -> Integer
 
-  def cycle: (?Integer n) { (Elem arg0) -> any } -> NilClass
+  def cycle: (?Integer n) { (Elem arg0) -> untyped } -> NilClass
            | (?Integer n) -> ::Enumerator[Elem, Return]
 
-  def detect: (?Proc ifnone) { (Elem arg0) -> any } -> Elem?
+  def detect: (?Proc ifnone) { (Elem arg0) -> untyped } -> Elem?
             | (?Proc ifnone) -> ::Enumerator[Elem, Return]
 
   def drop: (Integer n) -> ::Array[Elem]
 
-  def drop_while: () { (Elem arg0) -> any } -> ::Array[Elem]
+  def drop_while: () { (Elem arg0) -> untyped } -> ::Array[Elem]
                 | () -> ::Enumerator[Elem, Return]
 
-  def each_cons: (Integer n) { (::Array[Elem] arg0) -> any } -> NilClass
+  def each_cons: (Integer n) { (::Array[Elem] arg0) -> untyped } -> NilClass
                | (Integer n) -> ::Enumerator[::Array[Elem], Return]
 
-  def each_with_index: () { (Elem arg0, Integer arg1) -> any } -> ::Enumerable[Elem, Return]
+  def each_with_index: () { (Elem arg0, Integer arg1) -> untyped } -> ::Enumerable[Elem, Return]
                      | () -> ::Enumerator[[ Elem, Integer ], Return]
 
-  def each_with_object: [U] (U arg0) { (Elem arg0, any arg1) -> any } -> U
+  def each_with_object: [U] (U arg0) { (Elem arg0, untyped arg1) -> untyped } -> U
                       | [U] (U arg0) -> ::Enumerator[[ Elem, U ], Return]
 
   # Returns an array containing the items in *enum* .
@@ -96,11 +96,11 @@ module Enumerable[Elem, Return]: _Each[Elem, Return]
   # ```
   def entries: () -> ::Array[Elem]
 
-  def find_all: () { (Elem arg0) -> any } -> ::Array[Elem]
+  def find_all: () { (Elem arg0) -> untyped } -> ::Array[Elem]
               | () -> ::Enumerator[Elem, Return]
 
-  def find_index: (?any value) -> Integer?
-                | () { (Elem arg0) -> any } -> Integer?
+  def find_index: (?untyped value) -> Integer?
+                | () { (Elem arg0) -> untyped } -> Integer?
                 | () -> ::Enumerator[Elem, Return]
 
   # Returns the first element, or the first `n` elements, of the enumerable.
@@ -117,16 +117,16 @@ module Enumerable[Elem, Return]: _Each[Elem, Return]
   def first: () -> Elem?
            | (?Integer n) -> ::Array[Elem]?
 
-  def grep: (any arg0) -> ::Array[Elem]
-          | [U] (any arg0) { (Elem arg0) -> U } -> ::Array[U]
+  def grep: (untyped arg0) -> ::Array[Elem]
+          | [U] (untyped arg0) { (Elem arg0) -> U } -> ::Array[U]
 
   def group_by: [U] () { (Elem arg0) -> U } -> ::Hash[U, ::Array[Elem]]
               | () -> ::Enumerator[Elem, Return]
 
-  def `include?`: (any arg0) -> bool
+  def `include?`: (untyped arg0) -> bool
 
-  def inject: [Any] (?Any initial, ?Symbol arg0) -> any
-            | (?Symbol arg0) -> any
+  def inject: [A] (?A initial, ?Symbol arg0) -> untyped
+            | (?Symbol arg0) -> untyped
             | (?Elem initial) { (Elem arg0, Elem arg1) -> Elem } -> Elem
             | () { (Elem arg0, Elem arg1) -> Elem } -> Elem?
 
@@ -155,9 +155,9 @@ module Enumerable[Elem, Return]: _Each[Elem, Return]
          | (?Integer arg0) { (Elem arg0, Elem arg1) -> Integer } -> ::Array[Elem]
 
   def max_by: () -> ::Enumerator[Elem, Return]
-            | () { (Elem arg0) -> (Comparable | ::Array[any]) } -> Elem?
+            | () { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> Elem?
             | (?Integer arg0) -> ::Enumerator[Elem, Return]
-            | (?Integer arg0) { (Elem arg0) -> (Comparable | ::Array[any]) } -> ::Array[Elem]
+            | (?Integer arg0) { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> ::Array[Elem]
 
   # Returns the object in *enum* with the minimum value. The first form
   # assumes all objects implement `Comparable` ; the second uses the block
@@ -184,9 +184,9 @@ module Enumerable[Elem, Return]: _Each[Elem, Return]
          | (?Integer arg0) { (Elem arg0, Elem arg1) -> Integer } -> ::Array[Elem]
 
   def min_by: () -> ::Enumerator[Elem, Return]
-            | () { (Elem arg0) -> (Comparable | ::Array[any]) } -> Elem?
+            | () { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> Elem?
             | (?Integer arg0) -> ::Enumerator[Elem, Return]
-            | (?Integer arg0) { (Elem arg0) -> (Comparable | ::Array[any]) } -> ::Array[Elem]
+            | (?Integer arg0) { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> ::Array[Elem]
 
   # Returns a two element array which contains the minimum and the maximum
   # value in the enumerable. The first form assumes all objects implement
@@ -201,7 +201,7 @@ module Enumerable[Elem, Return]: _Each[Elem, Return]
             | () { (Elem arg0, Elem arg1) -> Integer } -> [ Elem?, Elem? ]
 
   def minmax_by: () -> [ Elem?, Elem? ]
-               | () { (Elem arg0) -> (Comparable | ::Array[any]) } -> ::Enumerator[Elem, Return]
+               | () { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> ::Enumerator[Elem, Return]
 
   # Passes each element of the collection to the given block. The method
   # returns `true` if the block never returns `true` for all elements. If
@@ -222,7 +222,7 @@ module Enumerable[Elem, Return]: _Each[Elem, Return]
   # [nil, false, true].none?                           #=> false
   # ```
   def none?: () -> bool
-           | () { (Elem arg0) -> any } -> bool
+           | () { (Elem arg0) -> untyped } -> bool
 
   # Passes each element of the collection to the given block. The method
   # returns `true` if the block returns `true` exactly once. If the block is
@@ -243,15 +243,15 @@ module Enumerable[Elem, Return]: _Each[Elem, Return]
   # [].one?                                            #=> false
   # ```
   def one?: () -> bool
-          | () { (Elem arg0) -> any } -> bool
+          | () { (Elem arg0) -> untyped } -> bool
 
-  def partition: () { (Elem arg0) -> any } -> [ ::Array[Elem], ::Array[Elem] ]
+  def partition: () { (Elem arg0) -> untyped } -> [ ::Array[Elem], ::Array[Elem] ]
                | () -> ::Enumerator[Elem, Return]
 
-  def reject: () { (Elem arg0) -> any } -> ::Array[Elem]
+  def reject: () { (Elem arg0) -> untyped } -> ::Array[Elem]
             | () -> ::Enumerator[Elem, Return]
 
-  def reverse_each: () { (Elem arg0) -> any } -> ::Enumerator[Elem, Return]
+  def reverse_each: () { (Elem arg0) -> untyped } -> ::Enumerator[Elem, Return]
                   | () -> ::Enumerator[Elem, Return]
 
   # Returns an array containing the items in *enum* sorted.
@@ -277,12 +277,12 @@ module Enumerable[Elem, Return]: _Each[Elem, Return]
   def sort: () -> ::Array[Elem]
           | () { (Elem arg0, Elem arg1) -> Integer } -> ::Array[Elem]
 
-  def sort_by: () { (Elem arg0) -> (Comparable | ::Array[any]) } -> ::Array[Elem]
+  def sort_by: () { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> ::Array[Elem]
              | () -> ::Enumerator[Elem, Return]
 
   def take: (Integer n) -> ::Array[Elem]?
 
-  def take_while: () { (Elem arg0) -> any } -> ::Array[Elem]
+  def take_while: () { (Elem arg0) -> untyped } -> ::Array[Elem]
                 | () -> ::Enumerator[Elem, Return]
 
   # Implemented in C++
@@ -299,12 +299,12 @@ module Enumerable[Elem, Return]: _Each[Elem, Return]
   # (1..5).to_h {|x| [x, x ** 2]}
   #   #=> {1=>1, 2=>4, 3=>9, 4=>16, 5=>25}
   # ```
-  def to_h: () -> ::Hash[any, any]
+  def to_h: () -> ::Hash[untyped, untyped]
 
-  def each_slice: (Integer n) { (::Array[Elem] arg0) -> any } -> NilClass
+  def each_slice: (Integer n) { (::Array[Elem] arg0) -> untyped } -> NilClass
                 | (Integer n) -> ::Enumerator[::Array[Elem], Return]
 
-  def find: (?Proc ifnone) { (Elem arg0) -> any } -> Elem?
+  def find: (?Proc ifnone) { (Elem arg0) -> untyped } -> Elem?
           | (?Proc ifnone) -> ::Enumerator[Elem, Return]
 
   def flat_map: [U] () { (Elem arg0) -> U } -> U
@@ -313,14 +313,14 @@ module Enumerable[Elem, Return]: _Each[Elem, Return]
   def map: [U] () { (Elem arg0) -> U } -> ::Array[U]
          | () -> ::Enumerator[Elem, Return]
 
-  def member?: (any arg0) -> bool
+  def member?: (untyped arg0) -> bool
 
-  def reduce: [Any] (?Any initial, ?Symbol arg0) -> any
-            | (?Symbol arg0) -> any
+  def reduce: [A] (?A initial, ?Symbol arg0) -> untyped
+            | (?Symbol arg0) -> untyped
             | (?Elem initial) { (Elem arg0, Elem arg1) -> Elem } -> Elem
             | () { (Elem arg0, Elem arg1) -> Elem } -> Elem?
 
-  def select: () { (Elem arg0) -> any } -> ::Array[Elem]
+  def select: () { (Elem arg0) -> untyped } -> ::Array[Elem]
             | () -> ::Enumerator[Elem, Return]
 
   # Returns an array containing the items in *enum* .

--- a/stdlib/builtin/enumerator.rbs
+++ b/stdlib/builtin/enumerator.rbs
@@ -98,7 +98,7 @@
 class Enumerator[Elem, Return] < Object
   include Enumerable[Elem, Return]
 
-  def each: () { (Elem arg0) -> any } -> Return
+  def each: () { (Elem arg0) -> untyped } -> Return
           | () -> self
 
   def feed: (Elem arg0) -> NilClass
@@ -235,10 +235,10 @@ class Enumerator[Elem, Return] < Object
   # ```
   def size: () -> (Integer | Float)?
 
-  def with_index: (?Integer offset) { (Elem arg0, Integer arg1) -> any } -> any
+  def with_index: (?Integer offset) { (Elem arg0, Integer arg1) -> untyped } -> untyped
                 | (?Integer offset) -> ::Enumerator[[ Elem, Integer ], Return]
 
-  def with_object: [U] (U arg0) { (Elem arg0, U arg1) -> any } -> any
+  def with_object: [U] (U arg0) { (Elem arg0, U arg1) -> untyped } -> untyped
                  | [U] (U arg0) -> ::Enumerator[[ Elem, U ], Return]
 end
 
@@ -250,7 +250,7 @@ class Enumerator::Lazy[Elem, Return] < Enumerator[Elem, Return]
 end
 
 class Enumerator::Yielder < Object
-  def <<: (*any arg0) -> void
+  def <<: (*untyped arg0) -> void
 
-  def yield: (*any arg0) -> void
+  def yield: (*untyped arg0) -> void
 end

--- a/stdlib/builtin/exception.rbs
+++ b/stdlib/builtin/exception.rbs
@@ -122,7 +122,7 @@
 # 
 #   - fatal – impossible to rescue
 class Exception < Object
-  def ==: (any arg0) -> bool
+  def ==: (untyped arg0) -> bool
 
   # Returns any backtrace associated with the exception. The backtrace is an
   # array of strings, each containing either “filename:lineNo: in \`method”‘

--- a/stdlib/builtin/false_class.rbs
+++ b/stdlib/builtin/false_class.rbs
@@ -5,14 +5,14 @@
 class FalseClass
   # And—Returns `false` . *obj* is always evaluated as it is the argument to
   # a method call—there is no short-circuit evaluation in this case.
-  def &: (any obj) -> FalseClass
+  def &: (untyped obj) -> FalseClass
 
   # Exclusive Or—If *obj* is `nil` or `false`, returns `false` ; otherwise,
   # returns `true` .
-  def ^: (any obj) -> bool
+  def ^: (untyped obj) -> bool
 
   # Or—Returns `false` if *obj* is `nil` or `false` ; `true` otherwise.
-  def |: (any obj) -> bool
+  def |: (untyped obj) -> bool
 
   def !: () -> TrueClass
 end

--- a/stdlib/builtin/file.rbs
+++ b/stdlib/builtin/file.rbs
@@ -30,7 +30,7 @@
 class File[Elem] < IO
   def self.absolute_path: (String file, ?String dir) -> String
 
-  def self.atime: (any file) -> Time
+  def self.atime: (untyped file) -> Time
 
   def self.basename: (String file, ?String suffix) -> String
 
@@ -38,7 +38,7 @@ class File[Elem] < IO
                   | (String arg0, ?Integer arg1) -> String
                   | (String arg0, ?Integer arg1, ?Integer arg2) -> String
 
-  def self.birthtime: (any file) -> Time
+  def self.birthtime: (untyped file) -> Time
 
   def self.blockdev?: (String | IO file) -> bool
 
@@ -48,7 +48,7 @@ class File[Elem] < IO
 
   def self.chown: (Integer owner, Integer group, *String files) -> Integer
 
-  def self.ctime: (any file) -> Time
+  def self.ctime: (untyped file) -> Time
 
   def self.delete: (*String files) -> Integer
 
@@ -60,9 +60,9 @@ class File[Elem] < IO
 
   def self.executable_real?: (String file) -> bool
 
-  def self.exist?: (any file) -> bool
+  def self.exist?: (untyped file) -> bool
 
-  def self.expand_path: (any file, ?any dir) -> String
+  def self.expand_path: (untyped file, ?untyped dir) -> String
 
   def self.extname: (String path) -> String
 
@@ -76,7 +76,7 @@ class File[Elem] < IO
 
   def self.identical?: (String | IO file_1, String | IO file_2) -> bool
 
-  def self.join: (*any arg0) -> String
+  def self.join: (*untyped arg0) -> String
 
   def self.lchmod: (Integer mode, *String files) -> Integer
 
@@ -86,7 +86,7 @@ class File[Elem] < IO
 
   def self.lstat: (String file) -> File::Stat
 
-  def self.mtime: (any file) -> Time
+  def self.mtime: (untyped file) -> Time
 
   def self.owned?: (String file) -> bool
 
@@ -118,7 +118,7 @@ class File[Elem] < IO
 
   def self.split: (String file) -> [ String, String ]
 
-  def self.stat: (any file) -> File::Stat
+  def self.stat: (untyped file) -> File::Stat
 
   def self.sticky?: (String file) -> bool
 

--- a/stdlib/builtin/fixnum.rbs
+++ b/stdlib/builtin/fixnum.rbs
@@ -1,1 +1,1 @@
-Fixnum: any
+Fixnum: untyped

--- a/stdlib/builtin/gc.rbs
+++ b/stdlib/builtin/gc.rbs
@@ -95,7 +95,7 @@ module GC::Profiler
 
   def self.enabled?: () -> bool
 
-  def self.raw_data: () -> ::Array[::Hash[Symbol, any]]
+  def self.raw_data: () -> ::Array[::Hash[Symbol, untyped]]
 
   def self.report: (?IO io) -> void
 

--- a/stdlib/builtin/hash.rbs
+++ b/stdlib/builtin/hash.rbs
@@ -178,19 +178,19 @@ class Hash[K, V] < Object
   def delete: (K arg0) -> V?
             | [U] (K arg0) { (K arg0) -> U } -> (U | V)
 
-  def delete_if: () { (K arg0, V arg1) -> any } -> ::Hash[K, V]
+  def delete_if: () { (K arg0, V arg1) -> untyped } -> ::Hash[K, V]
                | () -> ::Enumerator[[ K, V ], self]
 
-  def each: () { ([ K, V ] arg0) -> any } -> ::Hash[K, V]
+  def each: () { ([ K, V ] arg0) -> untyped } -> ::Hash[K, V]
           | () -> ::Enumerator[[ K, V ], self]
 
-  def each_key: () { (K arg0) -> any } -> ::Hash[K, V]
+  def each_key: () { (K arg0) -> untyped } -> ::Hash[K, V]
               | () -> ::Enumerator[[ K, V ], self]
 
-  def each_pair: () { (K arg0, V arg1) -> any } -> ::Hash[K, V]
+  def each_pair: () { (K arg0, V arg1) -> untyped } -> ::Hash[K, V]
                | () -> ::Enumerator[[ K, V ], self]
 
-  def each_value: () { (V arg0) -> any } -> ::Hash[K, V]
+  def each_value: () { (V arg0) -> untyped } -> ::Hash[K, V]
                 | () -> ::Enumerator[[ K, V ], self]
 
   # Returns `true` if *hsh* contains no key-value pairs.
@@ -209,8 +209,8 @@ class Hash[K, V] < Object
   def has_value?: (V arg0) -> bool
 
   def initialize: () -> void
-                | (?any default) -> void
-                | () { (Hash[any, any] hash, any key) -> any } -> void
+                | (?untyped default) -> void
+                | () { (Hash[untyped, untyped] hash, untyped key) -> untyped } -> void
 
   # Return the contents of this hash as a string.
   # 
@@ -256,7 +256,7 @@ class Hash[K, V] < Object
   # ```
   def invert: () -> ::Hash[V, K]
 
-  def keep_if: () { (K arg0, V arg1) -> any } -> ::Hash[K, V]
+  def keep_if: () { (K arg0, V arg1) -> untyped } -> ::Hash[K, V]
              | () -> ::Enumerator[[ K, V ], self]
 
   def key: (V arg0) -> K?
@@ -321,13 +321,13 @@ class Hash[K, V] < Object
   # h.reject {|k,v| v > 100}  #=> {"a" => 100}
   # ```
   def reject: () -> ::Enumerator[[ K, V ], self]
-            | () { (K arg0, V arg1) -> any } -> ::Hash[K, V]
+            | () { (K arg0, V arg1) -> untyped } -> ::Hash[K, V]
 
-  def reject!: () { (K arg0, V arg1) -> any } -> ::Hash[K, V]
+  def reject!: () { (K arg0, V arg1) -> untyped } -> ::Hash[K, V]
 
-  def select: () { (K arg0, V arg1) -> any } -> ::Hash[K, V]
+  def select: () { (K arg0, V arg1) -> untyped } -> ::Hash[K, V]
 
-  def select!: () { (K arg0, V arg1) -> any } -> ::Hash[K, V]
+  def select!: () { (K arg0, V arg1) -> untyped } -> ::Hash[K, V]
 
   # Removes a key-value pair from *hsh* and returns it as the two-item array
   # `[` *key, value* `]`, or the hash’s default value if the hash is empty.

--- a/stdlib/builtin/integer.rbs
+++ b/stdlib/builtin/integer.rbs
@@ -197,7 +197,7 @@ class Integer < Numeric
 
   def divmod: (Integer | Float | Rational | BigDecimal arg0) -> [ Integer | Float | Rational | BigDecimal, Integer | Float | Rational | BigDecimal ]
 
-  def downto: (Integer limit) { (Integer arg0) -> any } -> Integer
+  def downto: (Integer limit) { (Integer arg0) -> untyped } -> Integer
             | (Integer limit) -> ::Enumerator[Integer, self]
 
   def eql?: (Object arg0) -> bool
@@ -383,7 +383,7 @@ class Integer < Numeric
   # ```
   def succ: () -> Integer
 
-  def times: () { (Integer arg0) -> any } -> Integer
+  def times: () { (Integer arg0) -> untyped } -> Integer
            | () -> ::Enumerator[Integer, self]
 
   def to_c: () -> Complex
@@ -450,7 +450,7 @@ class Integer < Numeric
   # ```
   def truncate: () -> Integer
 
-  def upto: (Integer arg0) { (Integer arg0) -> any } -> Integer
+  def upto: (Integer arg0) { (Integer arg0) -> untyped } -> Integer
           | (Integer arg0) -> ::Enumerator[Integer, self]
 
   def zero?: () -> bool

--- a/stdlib/builtin/io.rbs
+++ b/stdlib/builtin/io.rbs
@@ -107,7 +107,7 @@ class IO < Object
 
   include Enumerable[String, IO]
 
-  def <<: (any arg0) -> self
+  def <<: (untyped arg0) -> self
 
   def advise: (Symbol arg0, ?Integer offset, ?Integer len) -> NilClass
 
@@ -209,16 +209,16 @@ class IO < Object
   # ```
   def closed?: () -> bool
 
-  def each: (?String sep, ?Integer limit) { (String arg0) -> any } -> self
+  def each: (?String sep, ?Integer limit) { (String arg0) -> untyped } -> self
           | (?String sep, ?Integer limit) -> ::Enumerator[String, self]
 
-  def each_byte: () { (Integer arg0) -> any } -> self
+  def each_byte: () { (Integer arg0) -> untyped } -> self
                | () -> ::Enumerator[Integer, self]
 
-  def each_char: () { (String arg0) -> any } -> self
+  def each_char: () { (String arg0) -> untyped } -> self
                | () -> ::Enumerator[String, self]
 
-  def each_codepoint: () { (Integer arg0) -> any } -> self
+  def each_codepoint: () { (Integer arg0) -> untyped } -> self
                     | () -> ::Enumerator[Integer, self]
 
   # Returns true if *ios* is at end of file that means there are no more
@@ -397,13 +397,13 @@ class IO < Object
 
   def pos=: (Integer arg0) -> Integer
 
-  def print: (*any arg0) -> NilClass
+  def print: (*untyped arg0) -> NilClass
 
-  def printf: (String format_string, *any arg0) -> NilClass
+  def printf: (String format_string, *untyped arg0) -> NilClass
 
-  def putc: (Numeric | String arg0) -> any
+  def putc: (Numeric | String arg0) -> untyped
 
-  def puts: (*any arg0) -> NilClass
+  def puts: (*untyped arg0) -> NilClass
 
   def read: (?Integer length, ?String outbuf) -> String?
 
@@ -512,36 +512,36 @@ class IO < Object
 
   def self.binread: (String name, ?Integer length, ?Integer offset) -> String
 
-  def self.binwrite: (String name, String arg0, ?Integer offset, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: any textmode, ?binmode: any binmode, ?autoclose: any autoclose, ?mode: String mode) -> Integer
+  def self.binwrite: (String name, String arg0, ?Integer offset, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: untyped textmode, ?binmode: untyped binmode, ?autoclose: untyped autoclose, ?mode: String mode) -> Integer
 
   def self.copy_stream: (String | IO src, String | IO dst, ?Integer copy_length, ?Integer src_offset) -> Integer
 
-  def self.popen: (*any args) -> any
+  def self.popen: (*untyped args) -> untyped
 
-  def self.read: (String name, ?Integer length, ?Integer offset, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: any textmode, ?binmode: any binmode, ?autoclose: any autoclose, ?mode: String mode) -> String
+  def self.read: (String name, ?Integer length, ?Integer offset, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: untyped textmode, ?binmode: untyped binmode, ?autoclose: untyped autoclose, ?mode: String mode) -> String
 
-  def self.readlines: (String name, ?String sep, ?Integer limit, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: any textmode, ?binmode: any binmode, ?autoclose: any autoclose, ?mode: String mode) -> ::Array[String]
+  def self.readlines: (String name, ?String sep, ?Integer limit, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: untyped textmode, ?binmode: untyped binmode, ?autoclose: untyped autoclose, ?mode: String mode) -> ::Array[String]
 
   def self.select: (::Array[IO]? read_array, ?::Array[IO]? write_array, ?::Array[IO]? error_array, ?Integer? timeout) -> ::Array[::Array[IO]]?
 
   def self.sysopen: (String path, ?String mode, ?String perm) -> Integer
 
-  def self.try_convert: (any arg0) -> IO?
+  def self.try_convert: (untyped arg0) -> IO?
 
-  def self.write: (String name, String arg0, ?Integer offset, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: any textmode, ?binmode: any binmode, ?autoclose: any autoclose, ?mode: String mode) -> Integer
+  def self.write: (String name, String arg0, ?Integer offset, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: untyped textmode, ?binmode: untyped binmode, ?autoclose: untyped autoclose, ?mode: String mode) -> Integer
 
   def self.for_fd: (Integer fd, ?Integer mode, ?Integer opt) -> self
 
-  def bytes: () { (Integer arg0) -> any } -> self
+  def bytes: () { (Integer arg0) -> untyped } -> self
            | () -> ::Enumerator[Integer, self]
 
-  def chars: () { (String arg0) -> any } -> self
+  def chars: () { (String arg0) -> untyped } -> self
            | () -> ::Enumerator[String, self]
 
-  def codepoints: () { (Integer arg0) -> any } -> self
+  def codepoints: () { (Integer arg0) -> untyped } -> self
                 | () -> ::Enumerator[Integer, self]
 
-  def each_line: (?String sep, ?Integer limit) { (String arg0) -> any } -> self
+  def each_line: (?String sep, ?Integer limit) { (String arg0) -> untyped } -> self
                | (?String sep, ?Integer limit) -> ::Enumerator[String, self]
 
   # Returns true if *ios* is at end of file that means there are no more
@@ -575,7 +575,7 @@ class IO < Object
   # `IO#rewind` first (which is not available for some streams).
   def eof?: () -> bool
 
-  def lines: (?String sep, ?Integer limit) { (String arg0) -> any } -> self
+  def lines: (?String sep, ?Integer limit) { (String arg0) -> untyped } -> self
            | (?String sep, ?Integer limit) -> ::Enumerator[String, self]
 
   # Alias for: [fileno](IO.downloaded.ruby_doc#method-i-fileno)

--- a/stdlib/builtin/kernel.rbs
+++ b/stdlib/builtin/kernel.rbs
@@ -18,7 +18,7 @@ module Kernel
   def caller_locations: (?Integer start_or_range, ?Integer length) -> ::Array[Thread::Backtrace::Location]?
                       | (?::Range[Integer] start_or_range) -> ::Array[Thread::Backtrace::Location]?
 
-  def catch: (?Object tag) { (Object arg0) -> any } -> any
+  def catch: (?Object tag) { (Object arg0) -> untyped } -> untyped
 
   # In a perfect world this should be:
   # 
@@ -30,12 +30,12 @@ module Kernel
   # 
   # is very surprising since users expect their methods to be present.
   # So we settle for untyped.
-  def `class`: () -> any
+  def `class`: () -> untyped
 
   def define_singleton_method: (Symbol | String symbol, ?Proc | Method | UnboundMethod method) -> Symbol
-                             | (Symbol | String symbol) { () -> any } -> Symbol
+                             | (Symbol | String symbol) { () -> untyped } -> Symbol
 
-  def eval: (String arg0, ?Binding arg1, ?String filename, ?Integer lineno) -> any
+  def eval: (String arg0, ?Binding arg1, ?String filename, ?Integer lineno) -> untyped
 
   # Returns `true` if `yield` would execute a block in the current context.
   # The `iterator?` form is mildly deprecated.
@@ -67,13 +67,13 @@ module Kernel
 
   def srand: (?Numeric number) -> Numeric
 
-  def !~: (any other) -> bool
+  def !~: (untyped other) -> bool
 
-  def <=>: (any other) -> Integer?
+  def <=>: (untyped other) -> Integer?
 
-  def ===: (any other) -> bool
+  def ===: (untyped other) -> bool
 
-  def =~: (any other) -> NilClass
+  def =~: (untyped other) -> NilClass
 
   def clone: () -> self
 
@@ -81,10 +81,10 @@ module Kernel
 
   def dup: () -> self
 
-  def enum_for: (?Symbol method, *any args) -> ::Enumerator[any, any]
-              | (?Symbol method, *any args) { () -> any } -> ::Enumerator[any, any]
+  def enum_for: (?Symbol method, *untyped args) -> ::Enumerator[untyped, untyped]
+              | (?Symbol method, *untyped args) { () -> untyped } -> ::Enumerator[untyped, untyped]
 
-  def eql?: (any other) -> bool
+  def eql?: (untyped other) -> bool
 
   def `extend`: (Module mod) -> NilClass
 
@@ -106,7 +106,7 @@ module Kernel
   # Note that fork(2) is not available on some platforms like Windows and
   # NetBSD 4. Therefore you should use spawn() instead of fork().
   def fork: () -> Integer?
-          | () { () -> any } -> Integer?
+          | () { () -> untyped } -> Integer?
 
   def freeze: () -> self
 
@@ -122,9 +122,9 @@ module Kernel
 
   def instance_variable_defined?: (Symbol | String arg0) -> bool
 
-  def instance_variable_get: (Symbol | String arg0) -> any
+  def instance_variable_get: (Symbol | String arg0) -> untyped
 
-  def instance_variable_set: (Symbol | String arg0, any arg1) -> any
+  def instance_variable_set: (Symbol | String arg0, untyped arg1) -> untyped
 
   def instance_variables: () -> ::Array[Symbol]
 
@@ -146,12 +146,12 @@ module Kernel
 
   def public_methods: (?bool all) -> ::Array[Symbol]
 
-  def `public_send`: (Symbol | String arg0, *any args) -> any
+  def `public_send`: (Symbol | String arg0, *untyped args) -> untyped
 
-  def remove_instance_variable: (Symbol arg0) -> any
+  def remove_instance_variable: (Symbol arg0) -> untyped
 
-  def `send`: (String | Symbol arg0, *any arg1) -> any
-            | (String | Symbol arg0, *any arg1) { () -> any } -> any
+  def `send`: (String | Symbol arg0, *untyped arg1) -> untyped
+            | (String | Symbol arg0, *untyped arg1) { () -> untyped } -> untyped
 
   def `singleton_class`: () -> Class
 
@@ -163,16 +163,16 @@ module Kernel
 
   def tainted?: () -> bool
 
-  def tap: () { (any x) -> void } -> self
+  def tap: () { (untyped x) -> void } -> self
 
-  def to_enum: (?Symbol method, *any args) -> ::Enumerator[any, any]
-             | (?Symbol method, *any args) { () -> any } -> ::Enumerator[any, any]
+  def to_enum: (?Symbol method, *untyped args) -> ::Enumerator[untyped, untyped]
+             | (?Symbol method, *untyped args) { () -> untyped } -> ::Enumerator[untyped, untyped]
 
   def to_s: () -> String
 
   def trust: () -> self
 
-  def `undef`: (*any arg) -> void
+  def `undef`: (*untyped arg) -> void
 
   def untaint: () -> self
 
@@ -199,8 +199,8 @@ module Kernel
   # Array(nil)         #=> []
   # Array(1)           #=> [1]
   # ```
-  def Array: (NilClass x) -> any
-           | (any x) -> ::Array[any]
+  def Array: (NilClass x) -> untyped
+           | (untyped x) -> ::Array[untyped]
 
   def BigDecimal: (Integer | Float | Rational | BigDecimal | String initial, ?Integer digits, ?exception: bool exception) -> BigDecimal
 
@@ -236,7 +236,7 @@ module Kernel
 
   def abort: (?String msg) -> bot
 
-  def at_exit: () { () -> any } -> Proc
+  def at_exit: () { () -> untyped } -> Proc
 
   def autoload: (String | Symbol _module, String filename) -> NilClass
 
@@ -337,7 +337,7 @@ module Kernel
           | (?Class arg0, ?::Array[String] arg1) -> bot
           | (?Class arg0, ?String arg1, ?::Array[String] arg2) -> bot
 
-  def format: (String format, *any args) -> String
+  def format: (String format, *untyped args) -> String
 
   def gets: (?String arg0, ?Integer arg1) -> String
 
@@ -378,8 +378,8 @@ module Kernel
   #   puts enum.next
   # } #=> :ok
   # ```
-  def loop: () { () -> any } -> bot
-          | () -> ::Enumerator[any, bot]
+  def loop: () { () -> untyped } -> bot
+          | () -> ::Enumerator[untyped, bot]
 
   def open: (String name, ?String | Integer rest, ?String block) -> IO?
 
@@ -402,17 +402,17 @@ module Kernel
   #     cat, 1, 2, 3, 99
   def print: (*Kernel args) -> NilClass
 
-  def printf: (?IO arg0, ?String arg1, *any arg2) -> NilClass
+  def printf: (?IO arg0, ?String arg1, *untyped arg2) -> NilClass
 
-  def proc: () { () -> any } -> Proc
+  def proc: () { () -> untyped } -> Proc
 
-  def lambda: () { () -> any } -> Proc
+  def lambda: () { () -> untyped } -> Proc
 
   def putc: (Integer arg0) -> Integer
 
-  def puts: (*any arg0) -> NilClass
+  def puts: (*untyped arg0) -> NilClass
 
-  def p: (*any arg0) -> NilClass
+  def p: (*untyped arg0) -> NilClass
 
   # If called without an argument, or if `max.to_i.abs == 0`, rand returns
   # a pseudo-random floating point number between 0.0 and 1.0, including 0.0
@@ -467,13 +467,13 @@ module Kernel
   def sleep: () -> bot
            | (Numeric duration) -> Integer
 
-  def sprintf: (String format, *any args) -> String
+  def sprintf: (String format, *untyped args) -> String
 
-  def syscall: (Integer num, *any args) -> any
+  def syscall: (Integer num, *untyped args) -> untyped
 
   def test: (String cmd, String file1, ?String file2) -> (TrueClass | FalseClass | Time)
 
-  def throw: (Object tag, ?any obj) -> bot
+  def throw: (Object tag, ?untyped obj) -> bot
 
   def warn: (*String msg) -> NilClass
 
@@ -609,4 +609,4 @@ module Kernel
   def system: (*String args) -> (NilClass | FalseClass | TrueClass)
 end
 
-Kernel::RUBYGEMS_ACTIVATION_MONITOR: any
+Kernel::RUBYGEMS_ACTIVATION_MONITOR: untyped

--- a/stdlib/builtin/match_data.rbs
+++ b/stdlib/builtin/match_data.rbs
@@ -1,5 +1,5 @@
 class MatchData < Object
-  def ==: (any arg0) -> bool
+  def ==: (untyped arg0) -> bool
 
   def []: (Integer i_or_start_or_range_or_name) -> String?
         | (Integer i_or_start_or_range_or_name, ?Integer length) -> ::Array[String]
@@ -21,7 +21,7 @@ class MatchData < Object
 
   def `end`: (Integer n) -> Integer
 
-  def eql?: (any other) -> bool
+  def eql?: (untyped other) -> bool
 
   # Produce a hash based on the target string, regexp and matched positions
   # of this matchdata.

--- a/stdlib/builtin/method.rbs
+++ b/stdlib/builtin/method.rbs
@@ -10,7 +10,7 @@ class Method < Object
   # m.call(3)    #=> 15
   # m.call(20)   #=> 32
   # ```
-  def call: (*any args) -> any
+  def call: (*untyped args) -> untyped
 
   # Returns a proc that is the composition of this method and the given *g*
   # . The returned proc takes a variable number of arguments, calls *g* with
@@ -25,7 +25,7 @@ class Method < Object
   # g = proc {|x| x + x }
   # p (f << g).call(2) #=> 16
   # ```
-  def <<: (any g) -> any
+  def <<: (untyped g) -> untyped
 
   # Invokes the method with `obj` as the parameter like
   # [call](Method.downloaded.ruby_doc#method-i-call). This allows a method
@@ -39,7 +39,7 @@ class Method < Object
   #   # ...
   # end
   # ```
-  def ===: (*any obj) -> any
+  def ===: (*untyped obj) -> untyped
 
   # Returns a proc that is the composition of this method and the given *g*
   # . The returned proc takes a variable number of arguments, calls *g* with
@@ -54,7 +54,7 @@ class Method < Object
   # g = proc {|x| x + x }
   # p (f >> g).call(2) #=> 8
   # ```
-  def >>: (any g) -> any
+  def >>: (untyped g) -> untyped
 
   # Invokes the *meth* with the specified arguments, returning the method’s
   # return value.
@@ -64,7 +64,7 @@ class Method < Object
   # m.call(3)    #=> 15
   # m.call(20)   #=> 32
   # ```
-  def []: (*any args) -> any
+  def []: (*untyped args) -> untyped
 
   # Returns an indication of the number of arguments accepted by a method.
   # Returns a nonnegative integer for methods that take a fixed number of
@@ -120,7 +120,7 @@ class Method < Object
   # ```
   def clone: () -> Method
 
-  def curry: (*any args) -> any
+  def curry: (*untyped args) -> untyped
 
   # Returns the name of the method.
   def name: () -> Symbol
@@ -158,18 +158,18 @@ class Method < Object
   # def foo(bar, baz, *args, &blk); end
   # method(:foo).parameters #=> [[:req, :bar], [:req, :baz], [:rest, :args], [:block, :blk]]
   # ```
-  def parameters: () -> ::Array[any]
+  def parameters: () -> ::Array[untyped]
 
   # Returns the bound receiver of the method object.
   # 
   # ```ruby
   # (1..3).method(:map).receiver # => 1..3
   # ```
-  def receiver: () -> any
+  def receiver: () -> untyped
 
   # Returns the Ruby source filename and line number containing this method
   # or nil if this method was not defined in Ruby (i.e. native).
-  def source_location: () -> any
+  def source_location: () -> untyped
 
   # Returns a [Method](Method.downloaded.ruby_doc) of superclass which would
   # be called when super is used or nil if there is no method on superclass.
@@ -178,5 +178,5 @@ class Method < Object
   # Dissociates *meth* from its current receiver. The resulting
   # `UnboundMethod` can subsequently be bound to a new object of the same
   # class (see `UnboundMethod` ).
-  def unbind: () -> any
+  def unbind: () -> untyped
 end

--- a/stdlib/builtin/module.rbs
+++ b/stdlib/builtin/module.rbs
@@ -58,9 +58,9 @@ class Module < Object
 
   def <=>: (Module other) -> Integer?
 
-  def ==: (any other) -> bool
+  def ==: (untyped other) -> bool
 
-  def ===: (any other) -> bool
+  def ===: (untyped other) -> bool
 
   def >: (Module other) -> bool?
 
@@ -96,39 +96,39 @@ class Module < Object
 
   def autoload?: (Symbol name) -> String?
 
-  def class_eval: (String arg0, ?String filename, ?Integer lineno) -> any
-                | [U] (any arg0) { (any m) -> U } -> U
+  def class_eval: (String arg0, ?String filename, ?Integer lineno) -> untyped
+                | [U] (untyped arg0) { (untyped m) -> U } -> U
 
-  def class_exec: (*any args) { () -> any } -> any
+  def class_exec: (*untyped args) { () -> untyped } -> untyped
 
   def class_variable_defined?: (Symbol | String arg0) -> bool
 
-  def class_variable_get: (Symbol | String arg0) -> any
+  def class_variable_get: (Symbol | String arg0) -> untyped
 
-  def class_variable_set: (Symbol | String arg0, any arg1) -> any
+  def class_variable_set: (Symbol | String arg0, untyped arg1) -> untyped
 
   def class_variables: (?bool inherit) -> ::Array[Symbol]
 
   def const_defined?: (Symbol | String arg0, ?bool inherit) -> bool
 
-  def const_get: (Symbol | String arg0, ?bool inherit) -> any
+  def const_get: (Symbol | String arg0, ?bool inherit) -> untyped
 
-  def const_missing: (Symbol arg0) -> any
+  def const_missing: (Symbol arg0) -> untyped
 
-  def const_set: (Symbol | String arg0, any arg1) -> any
+  def const_set: (Symbol | String arg0, untyped arg1) -> untyped
 
   def constants: (?bool inherit) -> ::Array[Symbol]
 
   def define_method: (Symbol | String arg0, ?Proc | Method | UnboundMethod arg1) -> Symbol
-                   | (Symbol | String arg0) { () -> any } -> Symbol
+                   | (Symbol | String arg0) { () -> untyped } -> Symbol
 
-  def eql?: (any other) -> bool
+  def eql?: (untyped other) -> bool
 
-  def equal?: (any other) -> bool
+  def equal?: (untyped other) -> bool
 
-  def extend_object: (any arg0) -> any
+  def extend_object: (untyped arg0) -> untyped
 
-  def extended: (Module othermod) -> any
+  def extended: (Module othermod) -> untyped
 
   # Prevents further modifications to *mod* .
   # 
@@ -139,7 +139,7 @@ class Module < Object
 
   def `include?`: (Module arg0) -> bool
 
-  def included: (Module othermod) -> any
+  def included: (Module othermod) -> untyped
 
   # Returns the list of modules included in *mod* .
   # 
@@ -157,22 +157,22 @@ class Module < Object
   def included_modules: () -> ::Array[Module]
 
   def initialize: () -> Object
-                | () { (Module arg0) -> any } -> void
+                | () { (Module arg0) -> untyped } -> void
 
   def instance_method: (Symbol arg0) -> UnboundMethod
 
   def instance_methods: (?bool include_super) -> ::Array[Symbol]
 
-  def method_added: (Symbol meth) -> any
+  def method_added: (Symbol meth) -> untyped
 
   def method_defined?: (Symbol | String arg0) -> bool
 
-  def method_removed: (Symbol method_name) -> any
+  def method_removed: (Symbol method_name) -> untyped
 
-  def module_eval: (String arg0, ?String filename, ?Integer lineno) -> any
-                 | [U] (any arg0) { (any m) -> U } -> U
+  def module_eval: (String arg0, ?String filename, ?Integer lineno) -> untyped
+                 | [U] (untyped arg0) { (untyped m) -> U } -> U
 
-  def module_exec: (*any args) { () -> any } -> any
+  def module_exec: (*untyped args) { () -> untyped } -> untyped
 
   def module_function: (*Symbol | String arg0) -> self
 
@@ -184,7 +184,7 @@ class Module < Object
 
   def prepend_features: (Module arg0) -> self
 
-  def prepended: (Module othermod) -> any
+  def prepended: (Module othermod) -> untyped
 
   def `private`: (*Symbol | String arg0) -> self
 
@@ -214,11 +214,11 @@ class Module < Object
 
   def public_method_defined?: (Symbol | String arg0) -> bool
 
-  def refine: (Class arg0) { (any arg0) -> any } -> self
+  def refine: (Class arg0) { (untyped arg0) -> untyped } -> self
 
-  def remove_class_variable: (Symbol arg0) -> any
+  def remove_class_variable: (Symbol arg0) -> untyped
 
-  def remove_const: (Symbol arg0) -> any
+  def remove_const: (Symbol arg0) -> untyped
 
   def remove_method: (Symbol | String arg0) -> self
 

--- a/stdlib/builtin/nil_class.rbs
+++ b/stdlib/builtin/nil_class.rbs
@@ -1,8 +1,8 @@
 # The class of the singleton object `nil` .
 class NilClass < Object
-  def &: (any obj) -> FalseClass
+  def &: (untyped obj) -> FalseClass
 
-  def ^: (any obj) -> bool
+  def ^: (untyped obj) -> bool
 
   # Returns zero as a rational. The optional argument `eps` is always
   # ignored.
@@ -13,7 +13,7 @@ class NilClass < Object
   # ```ruby
   # nil.to_a   #=> []
   # ```
-  def to_a: () -> any
+  def to_a: () -> untyped
 
   # Returns zero as a complex.
   def to_c: () -> Complex
@@ -30,12 +30,12 @@ class NilClass < Object
   # ```ruby
   # nil.to_h   #=> {}
   # ```
-  def to_h: () -> ::Hash[any, any]
+  def to_h: () -> ::Hash[untyped, untyped]
 
   # Returns zero as a rational.
   def to_r: () -> Rational
 
-  def |: (any obj) -> bool
+  def |: (untyped obj) -> bool
 
   # Only the object *nil* responds `true` to `nil?` .
   def `nil?`: () -> TrueClass

--- a/stdlib/builtin/numeric.rbs
+++ b/stdlib/builtin/numeric.rbs
@@ -263,7 +263,7 @@ class Numeric < Object
 
   def singleton_method_added: (Symbol arg0) -> TypeError
 
-  def step: (?Numeric? limit, ?Numeric step) { (Numeric arg0) -> any } -> Numeric
+  def step: (?Numeric? limit, ?Numeric step) { (Numeric arg0) -> untyped } -> Numeric
           | (?Numeric? limit, ?Numeric step) -> ::Enumerator[Numeric, self]
 
   # Returns the value as a complex.

--- a/stdlib/builtin/object.rbs
+++ b/stdlib/builtin/object.rbs
@@ -100,5 +100,5 @@ class Object < BasicObject
   # # does not meet condition, drop value
   # 2.yield_self.detect(&:odd?)            # => nil
   # ```
-  def then: () { (any arg) -> any } -> any
+  def then: () { (untyped arg) -> untyped } -> untyped
 end

--- a/stdlib/builtin/proc.rbs
+++ b/stdlib/builtin/proc.rbs
@@ -258,9 +258,9 @@ class Proc < Object
   # ```
   def binding: () -> Binding
 
-  def call: (*any arg0) -> any
+  def call: (*untyped arg0) -> untyped
 
-  def []: (*any arg0) -> any
+  def []: (*untyped arg0) -> untyped
 
   def curry: (?Integer arity) -> Proc
 

--- a/stdlib/builtin/process.rbs
+++ b/stdlib/builtin/process.rbs
@@ -12,7 +12,7 @@ module Process
 
   def self.clock_gettime: (Symbol | Integer clock_id, ?Symbol unit) -> (Float | Integer)
 
-  def self.daemon: (?any nochdir, ?any noclose) -> Integer
+  def self.daemon: (?untyped nochdir, ?untyped noclose) -> Integer
 
   def self.detach: (Integer pid) -> Thread
 
@@ -264,7 +264,7 @@ end
 class Process::Status < Object
   def &: (Integer num) -> Integer
 
-  def ==: (any other) -> bool
+  def ==: (untyped other) -> bool
 
   def >>: (Integer num) -> Integer
 

--- a/stdlib/builtin/random.rbs
+++ b/stdlib/builtin/random.rbs
@@ -24,7 +24,7 @@
 class Random < Object
   include Random::Formatter
 
-  def ==: (any arg0) -> bool
+  def ==: (untyped arg0) -> bool
 
   def bytes: (Integer size) -> String
 

--- a/stdlib/builtin/range.rbs
+++ b/stdlib/builtin/range.rbs
@@ -92,9 +92,9 @@ class Range[Elem] < Object
 
   def self.new: [U] (U from, U to, ?bool exclude_end) -> ::Range[U]
 
-  def ==: (any obj) -> bool
+  def ==: (untyped obj) -> bool
 
-  def ===: (any obj) -> bool
+  def ===: (untyped obj) -> bool
 
   # Returns the object that defines the beginning of the range.
   # 
@@ -105,9 +105,9 @@ class Range[Elem] < Object
 
   def bsearch: [U] () { (Elem arg0) -> bool } -> U?
 
-  def cover?: (any obj) -> bool
+  def cover?: (untyped obj) -> bool
 
-  def each: () { (Elem arg0) -> any } -> self
+  def each: () { (Elem arg0) -> untyped } -> self
           | () -> ::Enumerator[Elem, self]
 
   # Returns the object that defines the end of the range.
@@ -144,7 +144,7 @@ class Range[Elem] < Object
   # See also Object\#hash.
   def hash: () -> Integer
 
-  def `include?`: (any obj) -> bool
+  def `include?`: (untyped obj) -> bool
 
   def initialize: (Elem _begin, Elem _end, ?bool exclude_end) -> void
 
@@ -211,7 +211,7 @@ class Range[Elem] < Object
   # ```
   def size: () -> Integer?
 
-  def step: (?Integer n) { (Elem arg0) -> any } -> self
+  def step: (?Integer n) { (Elem arg0) -> untyped } -> self
           | (?Integer n) -> ::Enumerator[Elem, self]
 
   # Convert this range object to a printable form (using
@@ -219,7 +219,7 @@ class Range[Elem] < Object
   # and end objects).
   def to_s: () -> String
 
-  def eql?: (any obj) -> bool
+  def eql?: (untyped obj) -> bool
 
-  def member?: (any obj) -> bool
+  def member?: (untyped obj) -> bool
 end

--- a/stdlib/builtin/regexp.rbs
+++ b/stdlib/builtin/regexp.rbs
@@ -4,11 +4,11 @@ class Regexp < Object
   def self.last_match: () -> MatchData
                      | (?Integer arg0) -> String
 
-  def self.try_convert: (any obj) -> Regexp?
+  def self.try_convert: (untyped obj) -> Regexp?
 
-  def ==: (any other) -> bool
+  def ==: (untyped other) -> bool
 
-  def ===: (any other) -> bool
+  def ===: (untyped other) -> bool
 
   def =~: (String? str) -> Integer?
 
@@ -32,7 +32,7 @@ class Regexp < Object
   # See also Object\#hash.
   def hash: () -> Integer
 
-  def initialize: (String arg0, ?any options, ?String kcode) -> Object
+  def initialize: (String arg0, ?untyped options, ?String kcode) -> Object
                 | (Regexp arg0) -> void
 
   # Produce a nicely formatted string-version of *rxp* . Perhaps
@@ -104,12 +104,12 @@ class Regexp < Object
 
   def ~: () -> Integer?
 
-  def self.compile: (String arg0, ?any options, ?String kcode) -> self
+  def self.compile: (String arg0, ?untyped options, ?String kcode) -> self
                   | (Regexp arg0) -> self
 
   def self.quote: (String | Symbol arg0) -> String
 
-  def eql?: (any other) -> bool
+  def eql?: (untyped other) -> bool
 end
 
 Regexp::EXTENDED: Integer

--- a/stdlib/builtin/signal.rbs
+++ b/stdlib/builtin/signal.rbs
@@ -50,6 +50,6 @@ module Signal
 
   def self.signame: (Integer arg0) -> String?
 
-  def self.trap: (Integer | String | Symbol signal, ?any command) -> (String | Proc)
-               | (Integer | String | Symbol signal) { (Integer arg0) -> any } -> (String | Proc)
+  def self.trap: (Integer | String | Symbol signal, ?untyped command) -> (String | Proc)
+               | (Integer | String | Symbol signal) { (Integer arg0) -> untyped } -> (String | Proc)
 end

--- a/stdlib/builtin/string.rbs
+++ b/stdlib/builtin/string.rbs
@@ -20,9 +20,9 @@ class String < Object
 
   def <=>: (String other) -> Integer?
 
-  def ==: (any arg0) -> bool
+  def ==: (untyped arg0) -> bool
 
-  def ===: (any arg0) -> bool
+  def ===: (untyped arg0) -> bool
 
   %a{rbs:test:skip}
   def =~: (Object arg0) -> Integer?
@@ -147,7 +147,7 @@ class String < Object
   # If a block is given, which is a deprecated form, works the same as
   # `each_codepoint` .
   def codepoints: () -> ::Array[Integer]
-                | () { () -> any } -> ::Array[Integer]
+                | () { () -> untyped } -> ::Array[Integer]
 
   def concat: (Integer | Object arg0) -> String
 
@@ -226,16 +226,16 @@ class String < Object
   # ```
   def dump: () -> String
 
-  def each_byte: () { (Integer arg0) -> any } -> String
+  def each_byte: () { (Integer arg0) -> untyped } -> String
                | () -> ::Enumerator[Integer, self]
 
-  def each_char: () { (String arg0) -> any } -> String
+  def each_char: () { (String arg0) -> untyped } -> String
                | () -> ::Enumerator[String, self]
 
-  def each_codepoint: () { (Integer arg0) -> any } -> String
+  def each_codepoint: () { (Integer arg0) -> untyped } -> String
                     | () -> ::Enumerator[Integer, self]
 
-  def each_line: (?String arg0) { (String arg0) -> any } -> String
+  def each_line: (?String arg0) { (String arg0) -> untyped } -> String
                | (?String arg0) -> ::Enumerator[String, self]
 
   # Returns `true` if *str* has a length of zero.
@@ -261,12 +261,12 @@ class String < Object
 
   def gsub: (Regexp | String arg0, ?String arg1) -> String
           | (Regexp | String arg0, ?Hash[String, String] arg1) -> String
-          | (Regexp | String arg0) { (String arg0) -> any } -> String
+          | (Regexp | String arg0) { (String arg0) -> untyped } -> String
           | (Regexp | String arg0) -> ::Enumerator[String, self]
           | (Regexp | String arg0) -> String
 
   def gsub!: (Regexp | String arg0, ?String arg1) -> String?
-           | (Regexp | String arg0) { (String arg0) -> any } -> String?
+           | (Regexp | String arg0) { (String arg0) -> untyped } -> String?
            | (Regexp | String arg0) -> ::Enumerator[String, self]
 
   # Returns a hash based on the string’s length, content and encoding.
@@ -458,13 +458,13 @@ class String < Object
   def rstrip!: () -> String
 
   def scan: (Regexp | String arg0) -> ::Array[String | ::Array[String]]
-          | (Regexp | String arg0) { () -> any } -> ::Array[String | ::Array[String]]
+          | (Regexp | String arg0) { () -> untyped } -> ::Array[String | ::Array[String]]
 
   def scrub: (?String arg0) -> String
-           | (?String arg0) { (any arg0) -> any } -> String
+           | (?String arg0) { (untyped arg0) -> untyped } -> String
 
   def scrub!: (?String arg0) -> String
-            | (?String arg0) { (any arg0) -> any } -> String
+            | (?String arg0) { (untyped arg0) -> untyped } -> String
 
   def setbyte: (Integer arg0, Integer arg1) -> Integer
 
@@ -514,10 +514,10 @@ class String < Object
   def strip!: () -> String
 
   def sub: (Regexp | String arg0, ?String | Hash[String, String] arg1) -> String
-         | (Regexp | String arg0) { (String arg0) -> any } -> String
+         | (Regexp | String arg0) { (String arg0) -> untyped } -> String
 
   def sub!: (Regexp | String arg0, ?String arg1) -> String
-          | (Regexp | String arg0) { (String arg0) -> any } -> String
+          | (Regexp | String arg0) { (String arg0) -> untyped } -> String
 
   # Returns the successor to *str* . The successor is calculated by
   # incrementing characters starting from the rightmost alphanumeric (or the
@@ -681,7 +681,7 @@ class String < Object
   def upcase!: () -> String?
 
   def upto: [Bool] (String arg0, ?Bool arg1) -> ::Enumerator[String, self]
-          | [Bool] (String arg0, ?Bool arg1) { (String arg0) -> any } -> String
+          | [Bool] (String arg0, ?Bool arg1) { (String arg0) -> untyped } -> String
 
   # Returns true for a string which is encoded correctly.
   # 

--- a/stdlib/builtin/string_io.rbs
+++ b/stdlib/builtin/string_io.rbs
@@ -1,6 +1,6 @@
 class StringIO
-  def initialize: (?String, ?String) -> any
-  def puts: (*any) -> void
+  def initialize: (?String, ?String) -> untyped
+  def puts: (*untyped) -> void
   def readline: () -> String
               | (String) -> String
   def write: (String) -> void

--- a/stdlib/builtin/struct.rbs
+++ b/stdlib/builtin/struct.rbs
@@ -31,10 +31,10 @@ class Struct[Elem] < Object
 
   def initialize: (Symbol | String arg0, *Symbol | String arg1, ?keyword_init: bool keyword_init) -> void
 
-  def each: () { (Elem arg0) -> any } -> any
+  def each: () { (Elem arg0) -> untyped } -> untyped
           | () -> self
 
   def self.members: () -> ::Array[Symbol]
 
-  def new: (*any args) -> Struct[any]
+  def new: (*untyped args) -> Struct[untyped]
 end

--- a/stdlib/builtin/symbol.rbs
+++ b/stdlib/builtin/symbol.rbs
@@ -40,9 +40,9 @@ class Symbol < Object
 
   def <=>: (Symbol other) -> Integer?
 
-  def ==: (any obj) -> bool
+  def ==: (untyped obj) -> bool
 
-  def =~: (any obj) -> Integer?
+  def =~: (untyped obj) -> Integer?
 
   def []: (Integer idx_or_range) -> String
         | (Integer idx_or_range, ?Integer n) -> String
@@ -87,9 +87,9 @@ class Symbol < Object
   # Same as `sym.to_s.length` .
   def length: () -> Integer
 
-  def match: (any obj) -> Integer?
+  def match: (untyped obj) -> Integer?
 
-  def match?: (*any args) -> any
+  def match?: (*untyped args) -> untyped
 
   # Same as `sym.to_s.succ.intern` .
   def next: () -> Symbol

--- a/stdlib/builtin/thread.rbs
+++ b/stdlib/builtin/thread.rbs
@@ -191,7 +191,7 @@ class Thread < Object
   # Returns the main thread.
   def self.main: () -> Thread
 
-  def []: (String | Symbol key) -> any
+  def []: (String | Symbol key) -> untyped
 
   # Attribute Assignment—Sets or creates the value of a fiber-local
   # variable, using either a symbol or a string.
@@ -203,7 +203,7 @@ class Thread < Object
   # and
   # [thread\_variable\_get](Thread.downloaded.ruby_doc#method-i-thread_variable_get)
   # .
-  def []=: (String | Symbol key, any value) -> any
+  def []=: (String | Symbol key, untyped value) -> untyped
 
   def alive?: () -> bool
 
@@ -240,7 +240,7 @@ class Thread < Object
   # There is also a class level method to set this for all threads, see
   # [::abort\_on\_exception=](Thread.downloaded.ruby_doc#method-c-abort_on_exception-3D)
   # .
-  def abort_on_exception=: (bool abort_on_exception) -> any
+  def abort_on_exception=: (bool abort_on_exception) -> untyped
 
   # Adds *proc* as a handler for tracing.
   # 
@@ -249,10 +249,10 @@ class Thread < Object
   # and
   # [Kernel\#set\_trace\_func](https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-set_trace_func)
   # .
-  def add_trace_func: (any proc) -> any
+  def add_trace_func: (untyped proc) -> untyped
 
   # Returns the current backtrace of the target thread.
-  def backtrace: (*any args) -> ::Array[any]
+  def backtrace: (*untyped args) -> ::Array[untyped]
 
   # Returns the execution stack for the target thread—an array containing
   # backtrace location objects.
@@ -264,7 +264,7 @@ class Thread < Object
   # This method behaves similarly to
   # [Kernel\#caller\_locations](https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-caller_locations)
   # except it applies to a specific thread.
-  def backtrace_locations: (*any args) -> ::Array[any]?
+  def backtrace_locations: (*untyped args) -> ::Array[untyped]?
 
   # Terminates `thr` and schedules another thread to be run.
   # 
@@ -283,11 +283,11 @@ class Thread < Object
   # and
   # [Hash\#fetch](https://ruby-doc.org/core-2.6.3/Hash.html#method-i-fetch)
   # .
-  def fetch: (*any sym) -> any
+  def fetch: (*untyped sym) -> untyped
 
   def group: () -> ThreadGroup?
 
-  def initialize: (*any args) -> Thread
+  def initialize: (*untyped args) -> Thread
 
   # The calling thread will suspend execution and run this `thr` .
   # 
@@ -326,7 +326,7 @@ class Thread < Object
   #     Waiting
   #     tick...
   #     tick...
-  def join: (*any limit) -> Thread
+  def join: (*untyped limit) -> Thread
 
   # Returns `true` if the given string (or symbol) exists as a fiber-local
   # variable.
@@ -346,7 +346,7 @@ class Thread < Object
 
   # set given name to the ruby thread. On some platform, it may set the name
   # to pthread and/or kernel.
-  def name=: (any name) -> any
+  def name=: (untyped name) -> untyped
 
   # Returns whether or not the asynchronous queue is empty for the target
   # thread.
@@ -356,7 +356,7 @@ class Thread < Object
   # See
   # [::pending\_interrupt?](Thread.downloaded.ruby_doc#method-c-pending_interrupt-3F)
   # for more information.
-  def pending_interrupt?: (*any args) -> bool
+  def pending_interrupt?: (*untyped args) -> bool
 
   # Returns the priority of *thr* . Default is inherited from the current
   # thread which creating the new thread, or zero for the initial main
@@ -393,7 +393,7 @@ class Thread < Object
   # count1    #=> 622504
   # count2    #=> 5832
   # ```
-  def priority=: (Integer priority) -> any
+  def priority=: (Integer priority) -> untyped
 
   # Returns the status of the thread-local “report on exception” condition
   # for this `thr` .
@@ -424,7 +424,7 @@ class Thread < Object
   # There is also a class level method to set this for all new threads, see
   # [::report\_on\_exception=](Thread.downloaded.ruby_doc#method-c-report_on_exception-3D)
   # .
-  def report_on_exception=: (bool report_on_exception) -> any
+  def report_on_exception=: (bool report_on_exception) -> untyped
 
   # Wakes up `thr`, making it eligible for scheduling.
   # 
@@ -519,14 +519,14 @@ class Thread < Object
   # The value “bar” is returned for the thread local, where nil is returned
   # for the fiber local. The fiber is executed in the same thread, so the
   # thread local values are available.
-  def thread_variable_get: (any key) -> any
+  def thread_variable_get: (untyped key) -> untyped
 
   # Sets a thread local with `key` to `value` . Note that these are local to
   # threads, and not to fibers. Please see
   # [\#thread\_variable\_get](Thread.downloaded.ruby_doc#method-i-thread_variable_get)
   # and [\#\[\]](Thread.downloaded.ruby_doc#method-i-5B-5D) for more
   # information.
-  def thread_variable_set: (any key, any value) -> any
+  def thread_variable_set: (untyped key, untyped value) -> untyped
 
   def thread_variables: () -> ::Array[Symbol]
 
@@ -576,7 +576,7 @@ class Thread < Object
   # thread, see
   # [abort\_on\_exception](Thread.downloaded.ruby_doc#method-i-abort_on_exception)
   # .
-  def self.abort_on_exception: () -> any
+  def self.abort_on_exception: () -> untyped
 
   # When set to `true`, if any thread is aborted by an exception, the
   # raised exception will be re-raised in the main thread. Returns the new
@@ -608,14 +608,14 @@ class Thread < Object
   # thread, see
   # [abort\_on\_exception=](Thread.downloaded.ruby_doc#method-i-abort_on_exception-3D)
   # .
-  def self.abort_on_exception=: (any abort_on_exception) -> any
+  def self.abort_on_exception=: (untyped abort_on_exception) -> untyped
 
   # Wraps the block in a single, VM-global
   # [Mutex\#synchronize](https://ruby-doc.org/core-2.6.3/Mutex.html#method-i-synchronize)
   # , returning the value of the block. A thread executing inside the
   # exclusive section will only block other threads which also use the
   # [::exclusive](Thread.downloaded.ruby_doc#method-c-exclusive) mechanism.
-  def self.exclusive: () { () -> any } -> any
+  def self.exclusive: () { () -> untyped } -> untyped
 
   # Terminates the currently running thread and schedules another thread to
   # be run.
@@ -625,13 +625,13 @@ class Thread < Object
   # [Thread](Thread.downloaded.ruby_doc).
   # 
   # If this is the main thread, or the last thread, exit the process.
-  def self.exit: () -> any
+  def self.exit: () -> untyped
 
   # Basically the same as [::new](Thread.downloaded.ruby_doc#method-c-new).
   # However, if class [Thread](Thread.downloaded.ruby_doc) is subclassed,
   # then calling `start` in that subclass will not invoke the subclass’s
   # `initialize` method.
-  def self.fork: (*any args) -> any
+  def self.fork: (*untyped args) -> untyped
 
   # Changes asynchronous interrupt timing.
   # 
@@ -754,15 +754,15 @@ class Thread < Object
   #   # all exceptions inherited from Exception are prohibited.
   # }
   # ```
-  def self.handle_interrupt: (any hash) -> any
+  def self.handle_interrupt: (untyped hash) -> untyped
 
-  def self.kill: (Thread thread) -> any
+  def self.kill: (Thread thread) -> untyped
 
-  def self.list: () -> any
+  def self.list: () -> untyped
 
   # Give the thread scheduler a hint to pass execution to another thread. A
   # running thread may or may not switch, it depends on OS and processor.
-  def self.pass: () -> any
+  def self.pass: () -> untyped
 
   # Returns whether or not the asynchronous queue is empty.
   # 
@@ -819,17 +819,17 @@ class Thread < Object
   #     }
   #     ...
   #     flag = false # stop thread
-  def self.pending_interrupt?: (*any args) -> bool
+  def self.pending_interrupt?: (*untyped args) -> bool
 
-  def self.report_on_exception: () -> any
+  def self.report_on_exception: () -> untyped
 
-  def self.report_on_exception=: (any report_on_exception) -> any
+  def self.report_on_exception=: (untyped report_on_exception) -> untyped
 
   # Basically the same as [::new](Thread.downloaded.ruby_doc#method-c-new).
   # However, if class [Thread](Thread.downloaded.ruby_doc) is subclassed,
   # then calling `start` in that subclass will not invoke the subclass’s
   # `initialize` method.
-  def self.start: (*any args) -> any
+  def self.start: (*untyped args) -> untyped
 
   # Stops execution of the current thread, putting it into a “sleep” state,
   # and schedules execution of another thread.
@@ -842,7 +842,7 @@ class Thread < Object
   # a.join
   # #=> "abc"
   # ```
-  def self.`stop`: () -> any
+  def self.`stop`: () -> untyped
 end
 
 class Thread::Backtrace < Object
@@ -888,19 +888,19 @@ end
 # ```
 class Thread::ConditionVariable < Object
   # Wakes up all threads waiting for this lock.
-  def broadcast: () -> any
+  def broadcast: () -> untyped
 
-  def marshal_dump: () -> any
+  def marshal_dump: () -> untyped
 
   # Wakes up the first thread in line waiting for this lock.
-  def signal: () -> any
+  def signal: () -> untyped
 
   # Releases the lock held in `mutex` and waits; reacquires the lock on
   # wakeup.
   # 
   # If `timeout` is given, this method returns after `timeout` seconds
   # passed, even if no other thread doesn't signal.
-  def wait: (*any _) -> any
+  def wait: (*untyped _) -> untyped
 end
 
 # [Mutex](Mutex) implements a simple semaphore that
@@ -927,7 +927,7 @@ end
 class Thread::Mutex < Object
   # Attempts to grab the lock and waits if it isn’t available. Raises
   # `ThreadError` if `mutex` was locked by the current thread.
-  def lock: () -> any
+  def lock: () -> untyped
 
   # Returns `true` if this lock is currently held by some thread.
   def locked?: () -> bool
@@ -937,7 +937,7 @@ class Thread::Mutex < Object
 
   # Obtains a lock, runs the block, and releases the lock when the block
   # completes. See the example under `Mutex` .
-  def synchronize: () -> any
+  def synchronize: () -> untyped
 
   # Attempts to obtain the lock and returns immediately. Returns `true` if
   # the lock was granted.
@@ -945,7 +945,7 @@ class Thread::Mutex < Object
 
   # Releases the lock. Raises `ThreadError` if `mutex` wasn’t locked by the
   # current thread.
-  def unlock: () -> any
+  def unlock: () -> untyped
 end
 
 # The [Queue](Queue) class implements multi-producer,
@@ -982,10 +982,10 @@ end
 # ```
 class Thread::Queue < Object
   # Alias for: [push](Queue.downloaded.ruby_doc#method-i-push)
-  def <<: (any obj) -> any
+  def <<: (untyped obj) -> untyped
 
   # Removes all objects from the queue.
-  def clear: () -> any
+  def clear: () -> untyped
 
   # Closes the queue. A closed queue cannot be re-opened.
   # 
@@ -1017,19 +1017,19 @@ class Thread::Queue < Object
   #           end
   #         }
   #         q.close
-  def close: () -> any
+  def close: () -> untyped
 
   # Returns `true` if the queue is closed.
   def closed?: () -> bool
 
   # Alias for: [pop](Queue.downloaded.ruby_doc#method-i-pop)
-  def deq: (*any args) -> any
+  def deq: (*untyped args) -> untyped
 
   # Returns `true` if the queue is empty.
   def empty?: () -> bool
 
   # Alias for: [push](Queue.downloaded.ruby_doc#method-i-push)
-  def enq: (any obj) -> any
+  def enq: (untyped obj) -> untyped
 
   # Returns the length of the queue.
   # 
@@ -1038,10 +1038,10 @@ class Thread::Queue < Object
   # Also aliased as: [size](Queue.downloaded.ruby_doc#method-i-size)
   def length: () -> Integer
 
-  def marshal_dump: () -> any
+  def marshal_dump: () -> untyped
 
   # Returns the number of threads waiting on the queue.
-  def num_waiting: () -> any
+  def num_waiting: () -> untyped
 
   # Retrieves data from the queue.
   # 
@@ -1053,7 +1053,7 @@ class Thread::Queue < Object
   # 
   # Also aliased as: [deq](Queue.downloaded.ruby_doc#method-i-deq),
   # [shift](Queue.downloaded.ruby_doc#method-i-shift)
-  def pop: (*any args) -> any
+  def pop: (*untyped args) -> untyped
 
   # Pushes the given `object` to the queue.
   # 
@@ -1061,10 +1061,10 @@ class Thread::Queue < Object
   # 
   # Also aliased as: [enq](Queue.downloaded.ruby_doc#method-i-enq),
   # [\<\<](Queue.downloaded.ruby_doc#method-i-3C-3C)
-  def push: (any obj) -> any
+  def push: (untyped obj) -> untyped
 
   # Alias for: [pop](Queue.downloaded.ruby_doc#method-i-pop)
-  def shift: (*any args) -> any
+  def shift: (*untyped args) -> untyped
 
   # Alias for: [length](Queue.downloaded.ruby_doc#method-i-length)
   def size: () -> Integer
@@ -1077,18 +1077,18 @@ end
 # of how a [SizedQueue](SizedQueue) works.
 class Thread::SizedQueue < Thread::Queue
   # Alias for: [push](SizedQueue.downloaded.ruby_doc#method-i-push)
-  def <<: (*any args) -> any
+  def <<: (*untyped args) -> untyped
 
   # Alias for: [push](SizedQueue.downloaded.ruby_doc#method-i-push)
-  def enq: (*any args) -> any
+  def enq: (*untyped args) -> untyped
 
-  def initialize: (any max) -> SizedQueue
+  def initialize: (untyped max) -> SizedQueue
 
   # Returns the maximum size of the queue.
   def max: () -> Integer
 
   # Sets the maximum size of the queue to the given `number` .
-  def max=: (Integer max) -> any
+  def max=: (Integer max) -> untyped
 
   # Pushes `object` to the queue.
   # 
@@ -1100,13 +1100,13 @@ class Thread::SizedQueue < Thread::Queue
   # 
   # Also aliased as: [enq](SizedQueue.downloaded.ruby_doc#method-i-enq),
   # [\<\<](SizedQueue.downloaded.ruby_doc#method-i-3C-3C)
-  def push: (*any args) -> any
+  def push: (*untyped args) -> untyped
 end
 
-ConditionVariable: any
+ConditionVariable: untyped
 
-Mutex: any
+Mutex: untyped
 
-Queue: any
+Queue: untyped
 
-SizedQueue: any
+SizedQueue: untyped

--- a/stdlib/builtin/time.rbs
+++ b/stdlib/builtin/time.rbs
@@ -241,7 +241,7 @@ class Time < Object
   # ```
   def dst?: () -> bool
 
-  def eql?: (any arg0) -> bool
+  def eql?: (untyped arg0) -> bool
 
   # Returns `true` if *time* represents Friday.
   # 

--- a/stdlib/builtin/trace_point.rbs
+++ b/stdlib/builtin/trace_point.rbs
@@ -9,7 +9,7 @@ class TracePoint < Object
   # 
   # This method is only for debugging
   # [TracePoint](TracePoint.downloaded.ruby_doc) itself.
-  def self.stat: () -> any
+  def self.stat: () -> untyped
 
   def self.trace: (*Symbol events) { (TracePoint tp) -> void } -> TracePoint
 
@@ -75,10 +75,10 @@ class TracePoint < Object
   def path: () -> String
 
   # Value from exception raised on the `:raise` event
-  def raised_exception: () -> any
+  def raised_exception: () -> untyped
 
   # Return value from `:return`, `c_return`, and `b_return` event
-  def return_value: () -> any
+  def return_value: () -> untyped
 
   # Return the trace object during event
   # 

--- a/stdlib/builtin/unbound_method.rbs
+++ b/stdlib/builtin/unbound_method.rbs
@@ -118,7 +118,7 @@ class UnboundMethod
   #     In test, class = B
   #     prog.rb:16:in `bind': bind argument must be an instance of B (TypeError)
   #      from prog.rb:16
-  def bind: (any obj) -> Method
+  def bind: (untyped obj) -> Method
 
   # Returns the name of the method.
   def name: () -> Symbol

--- a/stdlib/set/set.rbs
+++ b/stdlib/set/set.rbs
@@ -1,28 +1,28 @@
 class Set[A]
   def self.`[]`: [X] (*X) -> Set[X]
 
-  def initialize: (_Each[A, any]) -> any
-                | [X] (_Each[X, any]) { (X) -> A } -> any
-                | (?nil) -> any
+  def initialize: (_Each[A, untyped]) -> untyped
+                | [X] (_Each[X, untyped]) { (X) -> A } -> untyped
+                | (?nil) -> untyped
 
-  def intersection: (_Each[A, any]) -> self
-  def &: (_Each[A, any]) -> self
+  def intersection: (_Each[A, untyped]) -> self
+  def &: (_Each[A, untyped]) -> self
 
-  def union: (_Each[A, any]) -> self
-  def `+`: (_Each[A, any]) -> self
-  def `|`: (_Each[A, any]) -> self
+  def union: (_Each[A, untyped]) -> self
+  def `+`: (_Each[A, untyped]) -> self
+  def `|`: (_Each[A, untyped]) -> self
 
-  def difference: (_Each[A, any]) -> self
-  def `-`: (_Each[A, any]) -> self
+  def difference: (_Each[A, untyped]) -> self
+  def `-`: (_Each[A, untyped]) -> self
 
   def add: (A) -> self
   def `<<`: (A) -> self
   def add?: (A) -> self?
 
-  def member?: (any) -> bool
-  def include?: (any) -> bool
+  def member?: (untyped) -> bool
+  def include?: (untyped) -> bool
 
-  def `^`: (_Each[A, any]) -> self
+  def `^`: (_Each[A, untyped]) -> self
 
   def classify: [X] { (A) -> X } -> Hash[X, self]
 
@@ -31,31 +31,31 @@ class Set[A]
   def collect!: { (A) -> A } -> self
   alias map! collect!
 
-  def delete: (any) -> self
-  def delete?: (any) -> self?
+  def delete: (untyped) -> self
+  def delete?: (untyped) -> self?
 
-  def delete_if: { (A) -> any } -> self
-  def reject!: { (A) -> any } -> self
+  def delete_if: { (A) -> untyped } -> self
+  def reject!: { (A) -> untyped } -> self
 
   def disjoint?: (self) -> bool
 
-  def divide: { (A, A) -> any } -> Set[self]
-            | { (A) -> any } -> Set[self]
+  def divide: { (A, A) -> untyped } -> Set[self]
+            | { (A) -> untyped } -> Set[self]
 
   def each: { (A) -> void } -> self
 
   def empty?: -> bool
 
-  def flatten: -> Set[any]
+  def flatten: -> Set[untyped]
 
   def intersect?: -> bool
 
-  def keep_if: { (A) -> any } -> self
+  def keep_if: { (A) -> untyped } -> self
 
   def size: -> Integer
   alias length size
 
-  def merge: (_Each[A, any]) -> self
+  def merge: (_Each[A, untyped]) -> self
 
   def subset?: (self) -> bool
   def proper_subst?: (self) -> bool
@@ -63,13 +63,13 @@ class Set[A]
   def superset?: (self) -> bool
   def proper_superset?: (self) -> bool
 
-  def replace: (_Each[A, any]) -> self
+  def replace: (_Each[A, untyped]) -> self
 
   def reset: -> self
 
-  def select!: { (A) -> any } -> self?
+  def select!: { (A) -> untyped } -> self?
 
-  def subtract: (_Each[A, any]) -> self
+  def subtract: (_Each[A, untyped]) -> self
 
   def to_a: -> Array[A]
 

--- a/test/ruby/signature/definition_builder_test.rb
+++ b/test/ruby/signature/definition_builder_test.rb
@@ -262,7 +262,7 @@ end
 
 interface _Hash
   def hash: -> Integer
-  def eql?: (any) -> bool
+  def eql?: (untyped) -> bool
 end
 
 interface _Baz
@@ -282,7 +282,7 @@ EOF
 
           assert_method_definition definition.methods[:bar], ["() -> ::_Foo"], accessibility: :public
           assert_method_definition definition.methods[:hash], ["() -> ::Integer"], accessibility: :public
-          assert_method_definition definition.methods[:eql?], ["(any) -> bool"], accessibility: :public
+          assert_method_definition definition.methods[:eql?], ["(untyped) -> bool"], accessibility: :public
         end
 
         assert_raises InvalidTypeApplicationError do
@@ -317,7 +317,7 @@ class Hello
 end
 
 extension Hello (Test)
-  def assert_equal: (any, any) -> void
+  def assert_equal: (untyped, untyped) -> void
   def self.setup: () -> void
 
   @name: String
@@ -338,7 +338,7 @@ EOF
           assert_equal [:assert_equal, :foo].sort, definition.methods.keys.sort
 
           definition.methods[:assert_equal].tap do |method|
-            assert_method_definition method, ["(any, any) -> void"], accessibility: :public
+            assert_method_definition method, ["(untyped, untyped) -> void"], accessibility: :public
           end
 
           definition.methods[:foo].tap do |method|
@@ -366,7 +366,7 @@ class Hello
 end
 
 extension Hello (Test)
-  def assert_equal: (any, any) -> void
+  def assert_equal: (untyped, untyped) -> void
   def self.setup: () -> void
 
   @name: String
@@ -446,7 +446,7 @@ EOF
 
         builder.build_one_singleton(BuiltinNames::String.name).yield_self do |definition|
           definition.methods[:try_convert].yield_self do |method|
-            assert_method_definition method, ["(any) -> ::String?"], accessibility: :public
+            assert_method_definition method, ["(untyped) -> ::String?"], accessibility: :public
           end
         end
       end
@@ -501,7 +501,7 @@ EOF
           end
 
           definition.methods[:puts].yield_self do |method|
-            assert_method_definition method, ["(*any) -> nil"], accessibility: :private
+            assert_method_definition method, ["(*untyped) -> nil"], accessibility: :private
           end
 
           definition.methods[:respond_to_missing?].yield_self do |method|
@@ -719,7 +719,7 @@ EOF
           assert_equal [:__id__, :initialize, :puts, :respond_to_missing?], definition.methods.keys.sort
           assert_method_definition definition.methods[:__id__], ["() -> ::Integer"]
           assert_method_definition definition.methods[:initialize], ["() -> void"]
-          assert_method_definition definition.methods[:puts], ["(*any) -> nil"]
+          assert_method_definition definition.methods[:puts], ["(*untyped) -> nil"]
           assert_method_definition definition.methods[:respond_to_missing?], ["(::Symbol, bool) -> bool"]
         end
       end

--- a/test/ruby/signature/environment_test.rb
+++ b/test/ruby/signature/environment_test.rb
@@ -54,8 +54,8 @@ end
         assert_equal parse_type("::Integer & ::Foo"), env.absolute_type(parse_type("Integer & Foo"), namespace: Namespace.root)
         assert_equal parse_type("::Integer & ::String::Foo"), env.absolute_type(parse_type("Integer & Foo"), namespace: Namespace.parse("::String"))
 
-        assert_equal parse_type("[::Foo, any]"), env.absolute_type(parse_type("[Foo, any]"), namespace: Namespace.root)
-        assert_equal parse_type("[::String::Foo, any]"), env.absolute_type(parse_type("[Foo, any]"), namespace: Namespace.parse("::String"))
+        assert_equal parse_type("[::Foo, untyped]"), env.absolute_type(parse_type("[Foo, untyped]"), namespace: Namespace.root)
+        assert_equal parse_type("[::String::Foo, untyped]"), env.absolute_type(parse_type("[Foo, untyped]"), namespace: Namespace.parse("::String"))
 
         assert_equal parse_type("{foo: ::Foo}"), env.absolute_type(parse_type("{ foo: Foo }"), namespace: Namespace.root)
         assert_equal parse_type("{foo: ::String::Foo }"), env.absolute_type(parse_type("{ foo: Foo }"), namespace: Namespace.parse("::String"))

--- a/test/ruby/signature/rbi_scaffold_test.rb
+++ b/test/ruby/signature/rbi_scaffold_test.rb
@@ -164,7 +164,7 @@ end
 
     assert_write parser.decls, <<-EOF
 class Hello
-  def hello: [U] (U arg0) { (Elem arg0) -> any } -> ::Array[U]
+  def hello: [U] (U arg0) { (Elem arg0) -> untyped } -> ::Array[U]
 end
     EOF
   end
@@ -203,8 +203,8 @@ end
 class Class
   def initialize: () -> void
                 | (?Class superclass) -> void
-                | () { (Class arg0) -> any } -> void
-                | (?Class superclass) { (Class arg0) -> any } -> void
+                | () { (Class arg0) -> untyped } -> void
+                | (?Class superclass) { (Class arg0) -> untyped } -> void
 end
     EOF
   end
@@ -325,7 +325,7 @@ end
 
     assert_write parser.decls, <<-EOF
 class Foo
-  def hello: () -> any
+  def hello: () -> untyped
 end
     EOF
   end

--- a/test/ruby/signature/signature_parsing_test.rb
+++ b/test/ruby/signature/signature_parsing_test.rb
@@ -13,7 +13,7 @@ class Ruby::Signature::SignatureParsingTest < Minitest::Test
   include TestHelper
 
   def test_type_alias
-    Parser.parse_signature("type Steep::foo = any").yield_self do |decls|
+    Parser.parse_signature("type Steep::foo = untyped").yield_self do |decls|
       assert_equal 1, decls.size
 
       type_decl = decls[0]
@@ -21,12 +21,12 @@ class Ruby::Signature::SignatureParsingTest < Minitest::Test
       assert_instance_of Declarations::Alias, type_decl
       assert_equal TypeName.new(name: :foo, namespace: Namespace.parse("Steep")), type_decl.name
       assert_equal Types::Bases::Any.new(location: nil), type_decl.type
-      assert_equal "type Steep::foo = any", type_decl.location.source
+      assert_equal "type Steep::foo = untyped", type_decl.location.source
     end
   end
 
   def test_constant
-    Parser.parse_signature("FOO: any").yield_self do |decls|
+    Parser.parse_signature("FOO: untyped").yield_self do |decls|
       assert_equal 1, decls.size
 
       const_decl = decls[0]
@@ -34,10 +34,10 @@ class Ruby::Signature::SignatureParsingTest < Minitest::Test
       assert_instance_of Declarations::Constant, const_decl
       assert_equal TypeName.new(name: :FOO, namespace: Namespace.empty), const_decl.name
       assert_equal Types::Bases::Any.new(location: nil), const_decl.type
-      assert_equal "FOO: any", const_decl.location.source
+      assert_equal "FOO: untyped", const_decl.location.source
     end
 
-    Parser.parse_signature("::BAR: any").yield_self do |decls|
+    Parser.parse_signature("::BAR: untyped").yield_self do |decls|
       assert_equal 1, decls.size
 
       const_decl = decls[0]
@@ -45,10 +45,10 @@ class Ruby::Signature::SignatureParsingTest < Minitest::Test
       assert_instance_of Declarations::Constant, const_decl
       assert_equal TypeName.new(name: :BAR, namespace: Namespace.root), const_decl.name
       assert_equal Types::Bases::Any.new(location: nil), const_decl.type
-      assert_equal "::BAR: any", const_decl.location.source
+      assert_equal "::BAR: untyped", const_decl.location.source
     end
 
-    Parser.parse_signature("FOO : any").yield_self do |decls|
+    Parser.parse_signature("FOO : untyped").yield_self do |decls|
       assert_equal 1, decls.size
 
       const_decl = decls[0]
@@ -56,10 +56,10 @@ class Ruby::Signature::SignatureParsingTest < Minitest::Test
       assert_instance_of Declarations::Constant, const_decl
       assert_equal TypeName.new(name: :FOO, namespace: Namespace.empty), const_decl.name
       assert_equal Types::Bases::Any.new(location: nil), const_decl.type
-      assert_equal "FOO : any", const_decl.location.source
+      assert_equal "FOO : untyped", const_decl.location.source
     end
 
-    Parser.parse_signature("::BAR : any").yield_self do |decls|
+    Parser.parse_signature("::BAR : untyped").yield_self do |decls|
       assert_equal 1, decls.size
 
       const_decl = decls[0]
@@ -67,12 +67,12 @@ class Ruby::Signature::SignatureParsingTest < Minitest::Test
       assert_instance_of Declarations::Constant, const_decl
       assert_equal TypeName.new(name: :BAR, namespace: Namespace.root), const_decl.name
       assert_equal Types::Bases::Any.new(location: nil), const_decl.type
-      assert_equal "::BAR : any", const_decl.location.source
+      assert_equal "::BAR : untyped", const_decl.location.source
     end
   end
 
   def test_global
-    Parser.parse_signature("$FOO: any").yield_self do |decls|
+    Parser.parse_signature("$FOO: untyped").yield_self do |decls|
       assert_equal 1, decls.size
 
       global_decl = decls[0]
@@ -80,7 +80,7 @@ class Ruby::Signature::SignatureParsingTest < Minitest::Test
       assert_instance_of Declarations::Global, global_decl
       assert_equal :"$FOO", global_decl.name
       assert_equal Types::Bases::Any.new(location: nil), global_decl.type
-      assert_equal "$FOO: any", global_decl.location.source
+      assert_equal "$FOO: untyped", global_decl.location.source
     end
   end
 
@@ -103,7 +103,7 @@ class Ruby::Signature::SignatureParsingTest < Minitest::Test
         # Yield all elements included in `self`.
         #  
         def count: -> Integer
-                 | (any) -> Integer
+                 | (untyped) -> Integer
                  | [X] { (A) -> X } -> Integer
 
         include _Hash[Integer]
@@ -132,7 +132,7 @@ class Ruby::Signature::SignatureParsingTest < Minitest::Test
           assert_empty t2.type_params
           assert_equal 1, t2.type.required_positionals.size
           assert_nil t2.block
-          assert_equal "(any) -> Integer", t2.location.source
+          assert_equal "(untyped) -> Integer", t2.location.source
 
           assert_equal [:X], t3.type_params
           assert_instance_of MethodType::Block, t3.block
@@ -187,7 +187,7 @@ class Ruby::Signature::SignatureParsingTest < Minitest::Test
         @@baz: Array[Integer]
 
         def one: -> void
-        def self.two: -> any
+        def self.two: -> untyped
         def self?.three: -> bool
 
         include X
@@ -245,7 +245,7 @@ class Ruby::Signature::SignatureParsingTest < Minitest::Test
       module_decl.members[4].yield_self do |m|
         assert_instance_of Members::MethodDefinition, m
         assert_equal :singleton, m.kind
-        assert_equal "def self.two: -> any", m.location.source
+        assert_equal "def self.two: -> untyped", m.location.source
       end
 
       module_decl.members[5].yield_self do |m|
@@ -388,7 +388,7 @@ class Ruby::Signature::SignatureParsingTest < Minitest::Test
       class Foo[X, Y]
         def foo: -> Integer
                | ?{ -> void } -> Integer
-               | [A] () { (String, ?Object, *Float, Symbol, foo: bool, ?bar: any, **Y) -> X } -> A
+               | [A] () { (String, ?Object, *Float, Symbol, foo: bool, ?bar: untyped, **Y) -> X } -> A
       end
     SIG
       assert_equal 1, decls.size
@@ -415,7 +415,7 @@ class Ruby::Signature::SignatureParsingTest < Minitest::Test
 
           m.types[2].yield_self do |ty|
             assert_instance_of MethodType, ty
-            assert_equal "[A] () { (String, ?Object, *Float, Symbol, foo: bool, ?bar: any, **Y) -> X } -> A", ty.location.source
+            assert_equal "[A] () { (String, ?Object, *Float, Symbol, foo: bool, ?bar: untyped, **Y) -> X } -> A", ty.location.source
             assert_instance_of MethodType::Block, ty.block
             assert ty.block.required
           end
@@ -530,24 +530,24 @@ class Ruby::Signature::SignatureParsingTest < Minitest::Test
         def type: -> String
         def module: -> String
         def private: -> String
-        def public: -> any
-        def &: (any) -> any
-        def ^: (any) -> any
-        def *: (any) -> any
-        def ==: (any) -> any
-        def <: (any) -> any
-        def <=: (any) -> any
-        def >: (any) -> any
-        def >=: (any) -> any
-        def end: -> any
-        def include: -> any
-        def extend: -> any
-        def attr_reader: -> any
-        def attr_accessor: -> any
-        def attr_writer: -> any
-        def `\\``: -> any
-        def def!: -> any
-        def !: -> any
+        def public: -> untyped
+        def &: (untyped) -> untyped
+        def ^: (untyped) -> untyped
+        def *: (untyped) -> untyped
+        def ==: (untyped) -> untyped
+        def <: (untyped) -> untyped
+        def <=: (untyped) -> untyped
+        def >: (untyped) -> untyped
+        def >=: (untyped) -> untyped
+        def end: -> untyped
+        def include: -> untyped
+        def extend: -> untyped
+        def attr_reader: -> untyped
+        def attr_accessor: -> untyped
+        def attr_writer: -> untyped
+        def `\\``: -> untyped
+        def def!: -> untyped
+        def !: -> untyped
       end
     SIG
       expected_names = [
@@ -641,7 +641,7 @@ class Ruby::Signature::SignatureParsingTest < Minitest::Test
     Parser.parse_signature(<<~SIG).yield_self do |decls|
       class Hello
         %a{noreturn}
-        def foo: () -> any
+        def foo: () -> untyped
 
         %a[incompatible]
         include Foo
@@ -739,8 +739,8 @@ end
     assert_valid_signature do
       <<-EOS
 class A
-  def =~: (any) -> bool
-  def ===: (any) -> bool
+  def =~: (untyped) -> bool
+  def ===: (untyped) -> bool
 end
       EOS
     end
@@ -748,7 +748,7 @@ end
     assert_valid_signature do
       <<-EOS
 class X
-  def foo: (type: any, class: any, module: any, if: any, include: any, yield: any, def: any, self: any, instance: any, any: any, void: void) -> any
+  def foo: (type: untyped, class: untyped, module: untyped, if: untyped, include: untyped, yield: untyped, def: untyped, self: untyped, instance: untyped, any: untyped, void: void) -> untyped
 end
       EOS
     end

--- a/test/ruby/signature/test_test.rb
+++ b/test/ruby/signature/test_test.rb
@@ -107,7 +107,7 @@ EOF
       manager.files[Pathname("foo.rbs")] = <<EOF
 class Foo
   def self.open: () { (String) -> void } -> Integer
-  def foo: (*any) -> String
+  def foo: (*untyped) -> String
 end
 EOF
       manager.build do |env|
@@ -262,7 +262,7 @@ EOF
           assert_empty errors
         end
 
-        parse_method_type("(parent: any, type: any) -> any").tap do |method_type|
+        parse_method_type("(parent: untyped, type: untyped) -> untyped").tap do |method_type|
           errors = []
           hook.typecheck_args "#foo",
                               method_type,

--- a/test/ruby/signature/type_parsing_test.rb
+++ b/test/ruby/signature/type_parsing_test.rb
@@ -18,6 +18,11 @@ class Ruby::Signature::TypeParsingTest < Minitest::Test
       assert_equal "any", type.location.source
     end
 
+    Parser.parse_type("untyped").yield_self do |type|
+      assert_instance_of Types::Bases::Any, type
+      assert_equal "untyped", type.location.source
+    end
+
     Parser.parse_type("bool").yield_self do |type|
       assert_instance_of Types::Bases::Bool, type
       assert_equal "bool", type.location.source

--- a/test/ruby/signature/type_parsing_test.rb
+++ b/test/ruby/signature/type_parsing_test.rb
@@ -88,11 +88,11 @@ class Ruby::Signature::TypeParsingTest < Minitest::Test
       assert_equal "::Enumerator::Lazy", type.location.source
     end
 
-    Parser.parse_type("Array[any]").yield_self do |type|
+    Parser.parse_type("Array[untyped]").yield_self do |type|
       assert_instance_of Types::ClassInstance, type
       assert_equal TypeName.new(namespace: Namespace.empty, name: :Array), type.name
       assert_equal [Types::Bases::Any.new(location: nil)], type.args
-      assert_equal "Array[any]", type.location.source
+      assert_equal "Array[untyped]", type.location.source
     end
   end
 
@@ -122,7 +122,7 @@ class Ruby::Signature::TypeParsingTest < Minitest::Test
     end
 
     assert_raises Parser::SyntaxError do
-      Parser.parse_type("foo[any]")
+      Parser.parse_type("foo[untyped]")
     end
   end
 
@@ -155,32 +155,32 @@ class Ruby::Signature::TypeParsingTest < Minitest::Test
       assert_equal "::Foo::_Foo", type.location.source
     end
 
-    Parser.parse_type("_Foo[any, nil]").yield_self do |type|
+    Parser.parse_type("_Foo[untyped, nil]").yield_self do |type|
       assert_instance_of Types::Interface, type
       assert_equal TypeName.new(namespace: Namespace.empty, name: :_Foo), type.name
       assert_equal [Types::Bases::Any.new(location: nil), Types::Bases::Nil.new(location: nil)], type.args
-      assert_equal "_Foo[any, nil]", type.location.source
+      assert_equal "_Foo[untyped, nil]", type.location.source
     end
   end
 
   def test_tuple
-    Parser.parse_type("[any, nil, void]").yield_self do |type|
+    Parser.parse_type("[untyped, nil, void]").yield_self do |type|
       assert_instance_of Types::Tuple, type
       assert_equal [
                      Types::Bases::Any.new(location: nil),
                      Types::Bases::Nil.new(location: nil),
                      Types::Bases::Void.new(location: nil)
                    ], type.types
-      assert_equal "[any, nil, void]", type.location.source
+      assert_equal "[untyped, nil, void]", type.location.source
     end
 
     assert_raises Parser::SyntaxError do
-      Parser.parse_type("[any]")
+      Parser.parse_type("[untyped]")
     end
   end
 
   def test_union_intersection
-    Parser.parse_type("any | void | nil").yield_self do |type|
+    Parser.parse_type("untyped | void | nil").yield_self do |type|
       assert_instance_of Types::Union, type
 
       assert_equal [
@@ -189,10 +189,10 @@ class Ruby::Signature::TypeParsingTest < Minitest::Test
                      Types::Bases::Nil.new(location: nil)
                    ], type.types
 
-      assert_equal "any | void | nil", type.location.source
+      assert_equal "untyped | void | nil", type.location.source
     end
 
-    Parser.parse_type("any & void & nil").yield_self do |type|
+    Parser.parse_type("untyped & void & nil").yield_self do |type|
       assert_instance_of Types::Intersection, type
 
       assert_equal [
@@ -201,28 +201,28 @@ class Ruby::Signature::TypeParsingTest < Minitest::Test
                      Types::Bases::Nil.new(location: nil)
                    ], type.types
 
-      assert_equal "any & void & nil", type.location.source
+      assert_equal "untyped & void & nil", type.location.source
     end
 
-    Parser.parse_type("any | void & nil").yield_self do |type|
+    Parser.parse_type("untyped | void & nil").yield_self do |type|
       assert_instance_of Types::Union, type
       assert_instance_of Types::Intersection, type.types[1]
 
-      assert_equal "any | void & nil", type.location.source
+      assert_equal "untyped | void & nil", type.location.source
     end
 
-    Parser.parse_type("any & void | nil").yield_self do |type|
+    Parser.parse_type("untyped & void | nil").yield_self do |type|
       assert_instance_of Types::Union, type
       assert_instance_of Types::Intersection, type.types[0]
 
-      assert_equal "any & void | nil", type.location.source
+      assert_equal "untyped & void | nil", type.location.source
     end
 
-    Parser.parse_type("any & (void | nil)").yield_self do |type|
+    Parser.parse_type("untyped & (void | nil)").yield_self do |type|
       assert_instance_of Types::Intersection, type
       assert_instance_of Types::Union, type.types[1]
 
-      assert_equal "any & (void | nil)", type.location.source
+      assert_equal "untyped & (void | nil)", type.location.source
     end
   end
 
@@ -259,7 +259,7 @@ class Ruby::Signature::TypeParsingTest < Minitest::Test
       assert_equal "^() -> void", type.location.source
     end
 
-    Parser.parse_type("^(any) -> void").yield_self do |type|
+    Parser.parse_type("^(untyped) -> void").yield_self do |type|
       assert_instance_of Types::Proc, type
 
       fun = type.type
@@ -274,10 +274,10 @@ class Ruby::Signature::TypeParsingTest < Minitest::Test
       assert_equal({}, fun.optional_keywords)
       assert_nil fun.rest_keywords
 
-      assert_equal "^(any) -> void", type.location.source
+      assert_equal "^(untyped) -> void", type.location.source
     end
 
-    Parser.parse_type("^(any, void) -> void").yield_self do |type|
+    Parser.parse_type("^(untyped, void) -> void").yield_self do |type|
       assert_instance_of Types::Proc, type
 
       fun = type.type
@@ -293,10 +293,10 @@ class Ruby::Signature::TypeParsingTest < Minitest::Test
       assert_equal({}, fun.optional_keywords)
       assert_nil fun.rest_keywords
 
-      assert_equal "^(any, void) -> void", type.location.source
+      assert_equal "^(untyped, void) -> void", type.location.source
     end
 
-    Parser.parse_type("^(any x, void _y) -> void").yield_self do |type|
+    Parser.parse_type("^(untyped x, void _y) -> void").yield_self do |type|
       assert_instance_of Types::Proc, type
 
       fun = type.type
@@ -312,10 +312,10 @@ class Ruby::Signature::TypeParsingTest < Minitest::Test
       assert_equal({}, fun.optional_keywords)
       assert_nil fun.rest_keywords
 
-      assert_equal "^(any x, void _y) -> void", type.location.source
+      assert_equal "^(untyped x, void _y) -> void", type.location.source
     end
 
-    Parser.parse_type("^(any x, ?void, ?nil y) -> void").yield_self do |type|
+    Parser.parse_type("^(untyped x, ?void, ?nil y) -> void").yield_self do |type|
       assert_instance_of Types::Proc, type
 
       fun = type.type
@@ -333,10 +333,10 @@ class Ruby::Signature::TypeParsingTest < Minitest::Test
       assert_equal({}, fun.optional_keywords)
       assert_nil fun.rest_keywords
 
-      assert_equal "^(any x, ?void, ?nil y) -> void", type.location.source
+      assert_equal "^(untyped x, ?void, ?nil y) -> void", type.location.source
     end
 
-    Parser.parse_type("^(any x, ?void, ?nil y, *any a) -> void").yield_self do |type|
+    Parser.parse_type("^(untyped x, ?void, ?nil y, *untyped a) -> void").yield_self do |type|
       assert_instance_of Types::Proc, type
 
       fun = type.type
@@ -355,10 +355,10 @@ class Ruby::Signature::TypeParsingTest < Minitest::Test
       assert_equal({}, fun.optional_keywords)
       assert_nil fun.rest_keywords
 
-      assert_equal "^(any x, ?void, ?nil y, *any a) -> void", type.location.source
+      assert_equal "^(untyped x, ?void, ?nil y, *untyped a) -> void", type.location.source
     end
 
-    Parser.parse_type("^(any x, *any a, nil z) -> void").yield_self do |type|
+    Parser.parse_type("^(untyped x, *untyped a, nil z) -> void").yield_self do |type|
       assert_instance_of Types::Proc, type
 
       fun = type.type
@@ -376,10 +376,10 @@ class Ruby::Signature::TypeParsingTest < Minitest::Test
       assert_equal({}, fun.optional_keywords)
       assert_nil fun.rest_keywords
 
-      assert_equal "^(any x, *any a, nil z) -> void", type.location.source
+      assert_equal "^(untyped x, *untyped a, nil z) -> void", type.location.source
     end
 
-    Parser.parse_type("^(foo: any, _bar: nil bar) -> void").yield_self do |type|
+    Parser.parse_type("^(foo: untyped, _bar: nil bar) -> void").yield_self do |type|
       assert_instance_of Types::Proc, type
 
       fun = type.type
@@ -395,10 +395,10 @@ class Ruby::Signature::TypeParsingTest < Minitest::Test
       assert_equal({}, fun.optional_keywords)
       assert_nil fun.rest_keywords
 
-      assert_equal "^(foo: any, _bar: nil bar) -> void", type.location.source
+      assert_equal "^(foo: untyped, _bar: nil bar) -> void", type.location.source
     end
 
-    Parser.parse_type("^(?_bar: nil, **any rest) -> void").yield_self do |type|
+    Parser.parse_type("^(?_bar: nil, **untyped rest) -> void").yield_self do |type|
       assert_instance_of Types::Proc, type
 
       fun = type.type
@@ -414,23 +414,23 @@ class Ruby::Signature::TypeParsingTest < Minitest::Test
       assert_equal Types::Function::Param.new(type: Types::Bases::Any.new(location: nil),
                                               name: :rest), fun.rest_keywords
 
-      assert_equal "^(?_bar: nil, **any rest) -> void", type.location.source
+      assert_equal "^(?_bar: nil, **untyped rest) -> void", type.location.source
     end
   end
 
   def test_optional
-    Parser.parse_type("any?").yield_self do |type|
+    Parser.parse_type("untyped?").yield_self do |type|
       assert_instance_of Types::Optional, type
       assert_instance_of Types::Bases::Any, type.type
 
-      assert_equal "any?", type.location.source
+      assert_equal "untyped?", type.location.source
     end
 
-    Parser.parse_type("^() -> any?").yield_self do |type|
+    Parser.parse_type("^() -> untyped?").yield_self do |type|
       assert_instance_of Types::Proc, type
     end
 
-    Parser.parse_type("any | void?").yield_self do |type|
+    Parser.parse_type("untyped | void?").yield_self do |type|
       assert_instance_of Types::Union, type
     end
   end
@@ -459,13 +459,13 @@ class Ruby::Signature::TypeParsingTest < Minitest::Test
   end
 
   def test_record
-    Parser.parse_type("{ foo: any, 3 => 'hoge' }").yield_self do |type|
+    Parser.parse_type("{ foo: untyped, 3 => 'hoge' }").yield_self do |type|
       assert_instance_of Types::Record, type
       assert_equal({
                      foo: Types::Bases::Any.new(location: nil),
                      3 => Types::Literal.new(literal: "hoge", location: nil)
                    }, type.fields)
-      assert_equal "{ foo: any, 3 => 'hoge' }", type.location.source
+      assert_equal "{ foo: untyped, 3 => 'hoge' }", type.location.source
     end
   end
 

--- a/test/ruby/signature/types_test.rb
+++ b/test/ruby/signature/types_test.rb
@@ -18,6 +18,6 @@ class Ruby::Signature::TypesTest < Minitest::Test
     assert_equal "(Integer | String & bool)?", parse_type("(Integer | String & bool)?").to_s
     assert_equal "((Integer | String) & bool)?", parse_type("((Integer | String) & bool)?").to_s
     assert_equal "^() -> void", parse_type("^() -> void").to_s
-    assert_equal "^(bool flag, ?any, *Symbol, name: String, ?email: nil, **Symbol) -> void", parse_type("^(bool flag, ?any, *Symbol, name: String, ?email: nil, **Symbol) -> void").to_s
+    assert_equal "^(bool flag, ?untyped, *Symbol, name: String, ?email: nil, **Symbol) -> void", parse_type("^(bool flag, ?untyped, *Symbol, name: String, ?email: nil, **Symbol) -> void").to_s
   end
 end

--- a/test/ruby/signature/writer_test.rb
+++ b/test/ruby/signature/writer_test.rb
@@ -110,7 +110,7 @@ interface _Each[X, Y]
 
   def `def`: () -> Symbol
 
-  def `: (String) -> any
+  def `: (String) -> untyped
 end
     SIG
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -61,7 +61,7 @@ end
 
 module Kernel
   private
-  def puts: (*any) -> nil
+  def puts: (*untyped) -> nil
 end
 
 class Class < Module
@@ -74,7 +74,7 @@ class String
   include Comparable
   prepend Enumerable[String, void]
 
-  def self.try_convert: (any) -> String?
+  def self.try_convert: (untyped) -> String?
 end
 
 class Integer


### PR DESCRIPTION
We are renaming `any` to `untyped` because of the following reasons:

* `any` is confusing: `any` is _?_ (TypeScript), _top type_ (Scala, Swift, ...), or _union type_ (Sorbet).
* `any` is difficult: people often build their own intuition like _any is a lie_ or _any is a compromise_.

Renaming to `untyped` would help to avoid these problems.

* `untyped` is closer name to the true _semantics_ of the type: no static type checking, runtime may type check.