### PR TITLE
Add () -> ::Array[::Array[Symbol]] to UnboundMethod#parameters signature

### DIFF
--- a/stdlib/builtin/unbound_method.rbs
+++ b/stdlib/builtin/unbound_method.rbs
@@ -146,6 +146,7 @@ class UnboundMethod
   # method(:foo).parameters #=> [[:req, :bar], [:req, :baz], [:rest, :args], [:block, :blk]]
   # ```
   def parameters: () -> ::Array[[ Symbol, Symbol ]]
+                | () -> ::Array[::Array[Symbol]]
 
   # Returns the Ruby source filename and line number containing this method
   # or nil if this method was not defined in Ruby (i.e. native).

--- a/test/stdlib/UnboundMethod_test.rb
+++ b/test/stdlib/UnboundMethod_test.rb
@@ -1,0 +1,9 @@
+class UnboundMethodTest < StdlibTest
+  target UnboundMethod
+  using hook.refinement
+
+  def test_parameters
+    42.method(:to_s).unbind.parameters
+    method(:test_parameters).unbind.parameters
+  end
+end


### PR DESCRIPTION
Builtin method does not have parameter name information.

```
42.method(:to_s).unbind.parameters
=> [[:rest]]
```