### PR TITLE
Fix BasicObject#instance_eval signature

### DIFF
--- a/stdlib/builtin/basic_object.rbs
+++ b/stdlib/builtin/basic_object.rbs
@@ -91,7 +91,7 @@ class BasicObject
   def equal?: (untyped other) -> bool
 
   def instance_eval: (?String arg0, ?String filename, ?Integer lineno) -> untyped
-                   | [U] () { () -> U } -> U
+                   | [U] () { (self) -> U } -> U
 
   def instance_exec: [U, V] (*V args) { (untyped args) -> U } -> U
 

--- a/test/stdlib/BasicObject_test.rb
+++ b/test/stdlib/BasicObject_test.rb
@@ -1,0 +1,8 @@
+class BasicObjectTest < StdlibTest
+  target BasicObject
+  using hook.refinement
+
+  def test_instance_eval
+    BasicObject.new.instance_eval { |x| x }
+  end
+end


### PR DESCRIPTION
```
irb(main):001:0> 42.instance_eval { p _1 }
42
=> 42
irb(main):002:-> 42.instance_eval(&->{})
Traceback (most recent call last):
        6: from /usr/local/var/rbenv/versions/master/bin/irb:23:in `<main>'
        5: from /usr/local/var/rbenv/versions/master/bin/irb:23:in `load'
        4: from /usr/local/var/rbenv/versions/master/lib/ruby/gems/2.7.0/gems/irb-1.1.0.pre.3/exe/irb:11:in `<top (required)>'
        3: from (irb):2
        2: from (irb):2:in `instance_eval'
        1: from (irb):2:in `block in irb_binding'
ArgumentError (wrong number of arguments (given 1, expected 0))
```