### PR TITLE
Fix type check of empty block args

### DIFF
--- a/lib/ruby/signature/test/hook.rb
+++ b/lib/ruby/signature/test/hook.rb
@@ -410,6 +410,8 @@ module Ruby
                    else
                      fun.rest_positionals
                    end
+                 elsif fun.required_positionals.empty? && fun.optional_positionals.empty?
+                   Types::Function::Param.new(name: nil, type: Types::Literal.new(location: nil, literal: []))
                  else
                    Types::Function::Param.new(name: nil, type: Types::Bases::Any.new(location: nil))
                  end)

--- a/test/ruby/signature/test_test.rb
+++ b/test/ruby/signature/test_test.rb
@@ -300,6 +300,29 @@ EOF
                               argument_error: Test::Hook::Errors::BlockArgumentError
           assert_empty errors.map {|e| Test::Hook::Errors.to_string(e) }
         end
+
+        parse_method_type("() { () -> void } -> void").tap do |method_type|
+          errors = []
+
+          hook.typecheck_args "#foo",
+                              method_type,
+                              hook.block_args(method_type.block.type),
+                              Test::Hook::ArgsReturn.new(arguments: [], return_value: nil),
+                              errors,
+                              type_error: Test::Hook::Errors::BlockArgumentTypeError,
+                              argument_error: Test::Hook::Errors::BlockArgumentError
+          assert_empty errors.map {|e| Test::Hook::Errors.to_string(e) }
+
+          errors.clear
+          hook.typecheck_args "#foo",
+                              method_type,
+                              hook.block_args(method_type.block.type),
+                              Test::Hook::ArgsReturn.new(arguments: [1], return_value: nil),
+                              errors,
+                              type_error: Test::Hook::Errors::BlockArgumentTypeError,
+                              argument_error: Test::Hook::Errors::BlockArgumentError
+          assert errors.any? {|error| error.is_a?(Test::Hook::Errors::BlockArgumentTypeError) }
+        end
       end
     end
   end


### PR DESCRIPTION
raise Test::Hook::Errors::BlockArgumentTypeError
when block args passed for `[U] () { () -> U } -> U`