### PR TITLE
Fix block typing

### DIFF
--- a/lib/ruby/signature/test/hook.rb
+++ b/lib/ruby/signature/test/hook.rb
@@ -293,7 +293,7 @@ module Ruby
 
           if method_type.block
             if call.block_call
-              typecheck_args(method_name, method_type, block_args(method_type.block.type), call.block_call, errors, type_error: Errors::BlockArgumentTypeError, argument_error: Errors::BlockArgumentError)
+              typecheck_args(method_name, method_type, method_type.block.type, call.block_call, errors, type_error: Errors::BlockArgumentTypeError, argument_error: Errors::BlockArgumentError)
               typecheck_return(method_name, method_type, method_type.block.type, call.block_call, errors, return_error: Errors::BlockReturnTypeError)
             else
               if method_type.block.required
@@ -395,27 +395,6 @@ module Ruby
           end
 
           true
-        end
-
-        def block_args(fun)
-          fun.update(
-               required_positionals: [],
-               trailing_positionals: [],
-               optional_positionals: fun.required_positionals + fun.optional_positionals,
-               rest_positionals:
-                 if fun.rest_positionals
-                   unless fun.trailing_positionals.empty?
-                     types = [
-                       fun.rest_positionals,
-                       *fun.trailing_positionals,
-                     ].compact
-                     Types::Union.new(types: types, location: nil)
-                   else
-                     fun.rest_positionals
-                   end
-                 else
-                   Types::Function::Param.new(name: nil, type: Types::Bases::Any.new(location: nil))
-                 end)
         end
 
         def zip_args(args, fun, &block)

--- a/stdlib/builtin/basic_object.rbs
+++ b/stdlib/builtin/basic_object.rbs
@@ -93,7 +93,7 @@ class BasicObject
   def instance_eval: (?String arg0, ?String filename, ?Integer lineno) -> untyped
                    | [U] () { (self) -> U } -> U
 
-  def instance_exec: [U, V] (*V args) { (untyped args) -> U } -> U
+  def instance_exec: [U, V] (*V args) { (*V args) -> U } -> U
 
   private
   def initialize: () -> void

--- a/test/ruby/signature/test_test.rb
+++ b/test/ruby/signature/test_test.rb
@@ -277,29 +277,6 @@ EOF
                               argument_error: Test::Hook::Errors::ArgumentError
           assert_empty errors.map {|e| Test::Hook::Errors.to_string(e) }
         end
-
-        parse_method_type("() { (Integer) -> void } -> void").tap do |method_type|
-          errors = []
-
-          hook.typecheck_args "#foo",
-                              method_type,
-                              hook.block_args(method_type.block.type),
-                              Test::Hook::ArgsReturn.new(arguments: [], return_value: nil),
-                              errors,
-                              type_error: Test::Hook::Errors::BlockArgumentTypeError,
-                              argument_error: Test::Hook::Errors::BlockArgumentError
-          assert_empty errors.map {|e| Test::Hook::Errors.to_string(e) }
-
-          errors.clear
-          hook.typecheck_args "#foo",
-                              method_type,
-                              hook.block_args(method_type.block.type),
-                              Test::Hook::ArgsReturn.new(arguments: [1,2], return_value: nil),
-                              errors,
-                              type_error: Test::Hook::Errors::BlockArgumentTypeError,
-                              argument_error: Test::Hook::Errors::BlockArgumentError
-          assert_empty errors.map {|e| Test::Hook::Errors.to_string(e) }
-        end
       end
     end
   end

--- a/test/stdlib/BasicObject_test.rb
+++ b/test/stdlib/BasicObject_test.rb
@@ -5,4 +5,9 @@ class BasicObjectTest < StdlibTest
   def test_instance_eval
     BasicObject.new.instance_eval { |x| x }
   end
+
+  def test_instance_exec
+    BasicObject.new.instance_exec(1) { 10 }
+    BasicObject.new.instance_exec(1,2,3) { 10 }
+  end
 end


### PR DESCRIPTION
Related to #43.

* `yield`s should give all required arguments.
* The blocks may ignore the given arguments.