### PR TITLE
Remove the arithmetic rules of (Integer|Float) -> (Integer|Float)

### DIFF
--- a/stdlib/builtin/float.rbs
+++ b/stdlib/builtin/float.rbs
@@ -21,7 +21,6 @@ class Float < Numeric
        | (Rational arg0) -> Float
        | (BigDecimal arg0) -> BigDecimal
        | (Complex arg0) -> Complex
-       | (Integer | Float arg0) -> Float
 
   def **: (Integer arg0) -> Float
         | (Float arg0) -> Float
@@ -34,7 +33,6 @@ class Float < Numeric
        | (Rational arg0) -> Float
        | (BigDecimal arg0) -> BigDecimal
        | (Complex arg0) -> Complex
-       | (Integer | Float arg0) -> Float
 
   def +@: () -> Float
 
@@ -43,7 +41,6 @@ class Float < Numeric
        | (Rational arg0) -> Float
        | (BigDecimal arg0) -> BigDecimal
        | (Complex arg0) -> Complex
-       | (Integer | Float arg0) -> Float
 
   def -@: () -> Float
 
@@ -52,7 +49,6 @@ class Float < Numeric
        | (Rational arg0) -> Float
        | (BigDecimal arg0) -> BigDecimal
        | (Complex arg0) -> Complex
-       | (Integer | Float arg0) -> Float
 
   def <: (Integer arg0) -> bool
        | (Float arg0) -> bool

--- a/stdlib/builtin/integer.rbs
+++ b/stdlib/builtin/integer.rbs
@@ -7,7 +7,6 @@ class Integer < Numeric
        | (Float arg0) -> Float
        | (Rational arg0) -> Rational
        | (BigDecimal arg0) -> BigDecimal
-       | (Integer | Float arg0) -> (Integer | Float)
 
   def &: (Integer arg0) -> Integer
 
@@ -16,7 +15,6 @@ class Integer < Numeric
        | (Rational arg0) -> Rational
        | (BigDecimal arg0) -> BigDecimal
        | (Complex arg0) -> Complex
-       | (Integer | Float arg0) -> (Integer | Float)
 
   def **: (Integer arg0) -> Numeric
         | (Float arg0) -> Numeric
@@ -29,7 +27,6 @@ class Integer < Numeric
        | (Rational arg0) -> Rational
        | (BigDecimal arg0) -> BigDecimal
        | (Complex arg0) -> Complex
-       | (Integer | Float arg0) -> (Integer | Float)
 
   def +@: () -> Integer
 
@@ -38,7 +35,6 @@ class Integer < Numeric
        | (Rational arg0) -> Rational
        | (BigDecimal arg0) -> BigDecimal
        | (Complex arg0) -> Complex
-       | (Integer | Float arg0) -> (Integer | Float)
 
   def -@: () -> Integer
 
@@ -47,7 +43,6 @@ class Integer < Numeric
        | (Rational arg0) -> Rational
        | (BigDecimal arg0) -> BigDecimal
        | (Complex arg0) -> Complex
-       | (Integer | Float arg0) -> (Integer | Float)
 
   def <: (Integer arg0) -> bool
        | (Float arg0) -> bool


### PR DESCRIPTION
Some artithmetic methods, such as `Integer#+`, have three rules:
`(Integer) -> Integer`, `(Float) -> Float`, and
`(Integer|Float) -> (Integer|Float)`.

This change removes the third rules which I don't see any reason to
have.