### PR TITLE
Use relative path for Gem::Specification#files

### DIFF
--- a/ruby-signature.gemspec
+++ b/ruby-signature.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.files << File.join(__dir__, "lib/ruby/signature/parser.rb")
+  spec.files << "lib/ruby/signature/parser.rb"
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
# Problem


It cannot be installed with Ruby master.

```bash
$ ruby -v
ruby 2.7.0dev (2019-10-30T15:38:16Z master 5f8795a07b) [x86_64-linux]

$ gem install pkg/ruby-signature-0.1.0.gem
ERROR:  While executing gem ... (Gem::Package::PathError)
    installing into parent path /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/parser.rb of /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/ruby-signature-0.1.0 is not allowed
```

I guess the cause is this commit of rubygems. https://github.com/rubygems/rubygems/commit/e2b5c58de49b83381d7971f5bb1d901721ed5818
It makes symlink checking restrict, and the check disallows the absolute path.



# Solution

Use a relative path instead of the absolute path.

I'm not sure it is a rubygems's matter, or not.
But absolute path is meaningless for Gem::Specification#files. So I think this change is meaningful even if rubygems is fixed.



Thanks! @hanachin 
