### PR TITLE
Use StringScanner#charpos

### DIFF
--- a/lib/ruby/signature/buffer.rb
+++ b/lib/ruby/signature/buffer.rb
@@ -45,7 +45,7 @@ module Ruby
       end
 
       def last_position
-        content.bytesize
+        content.size
       end
     end
   end

--- a/lib/ruby/signature/parser.y
+++ b/lib/ruby/signature/parser.y
@@ -1116,8 +1116,8 @@ def push_comment(string, location)
 end
 
 def new_token(type, value = input.matched)
-  start_index = input.pos - input.matched.bytesize
-  end_index = input.pos
+  start_index = input.charpos - input.matched.size
+  end_index = input.charpos
 
   location = Ruby::Signature::Location.new(buffer: buffer,
                                            start_pos: start_index,
@@ -1240,8 +1240,8 @@ def next_token
     when input.scan(/\s+/)
       # skip
     when input.scan(/#(( *)|( (?<string>.*)))\n/)
-      start_index = input.pos - input.matched.size
-      end_index = input.pos-1
+      start_index = input.charpos - input.matched.size
+      end_index = input.charpos-1
 
       location = Ruby::Signature::Location.new(buffer: buffer,
                                                start_pos: start_index,

--- a/test/ruby/signature/signature_parsing_test.rb
+++ b/test/ruby/signature/signature_parsing_test.rb
@@ -918,4 +918,15 @@ end
       assert c.skip_validation
     end
   end
+
+  def test_mame
+    Parser.parse_signature(<<EOF).yield_self do |decls|
+# h –
+class Exception < Object
+end
+EOF
+
+      assert_equal "class Exception < Object", decls[0].location.source.lines[0].chomp
+    end
+  end
 end


### PR DESCRIPTION
`StringScanner#pos` is based on bytes, which results in incorrect character positions with multibyte (Unicode) characters. We need to use `#charpos` instead.

@mame reported this issue.