### PR TITLE
Fix error when run `exe/rbs methods` without argument

### DIFF
--- a/lib/ruby/signature/cli.rb
+++ b/lib/ruby/signature/cli.rb
@@ -202,6 +202,11 @@ module Ruby
           opts.on("--no-inherit") { inherit = false }
         end.order!(args)
 
+        unless args.size == 1
+          stdout.puts "Expected one argument."
+          return
+        end
+
         loader = EnvironmentLoader.new()
 
         options.setup(loader)


### PR DESCRIPTION
```
% exe/rbs methods
Traceback (most recent call last):
        6: from exe/rbs:3:in `<main>'
        5: from exe/rbs:3:in `load'
        4: from /home/sei/src/github.com/ruby/ruby-signature/exe/ruby-signature:7:in `<top (required)>'
        3: from /home/sei/src/github.com/ruby/ruby-signature/lib/ruby/signature/cli.rb:81:in `run'
        2: from /home/sei/src/github.com/ruby/ruby-signature/lib/ruby/signature/cli.rb:213:in `run_methods'
        1: from /home/sei/src/github.com/ruby/ruby-signature/lib/ruby/signature/cli.rb:425:in `parse_type_name'
/home/sei/src/github.com/ruby/ruby-signature/lib/ruby/signature/namespace.rb:85:in `parse': undefined method `start_with?' for nil:NilClass (NoMethodError)
```