### PR TITLE
Silence warn `any` type is deprecated

### DIFF
--- a/test/ruby/signature/type_parsing_test.rb
+++ b/test/ruby/signature/type_parsing_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class Ruby::Signature::TypeParsingTest < Minitest::Test
+  include TestHelper
+
   Parser = Ruby::Signature::Parser
   Buffer = Ruby::Signature::Buffer
   Types = Ruby::Signature::Types
@@ -13,9 +15,11 @@ class Ruby::Signature::TypeParsingTest < Minitest::Test
       assert_equal "void", type.location.source
     end
 
-    Parser.parse_type("any").yield_self do |type|
-      assert_instance_of Types::Bases::Any, type
-      assert_equal "any", type.location.source
+    silence_warnings do
+      Parser.parse_type("any").yield_self do |type|
+        assert_instance_of Types::Bases::Any, type
+        assert_equal "any", type.location.source
+      end
     end
 
     Parser.parse_type("untyped").yield_self do |type|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,6 +22,12 @@ module TestHelper
     end
   end
 
+  def silence_warnings
+    Ruby::Signature.logger.stub :warn, nil do
+      yield
+    end
+  end
+
   class SignatureManager
     attr_reader :files
 


### PR DESCRIPTION
## Before

```
$ ruby -r bundler/setup -r pry-byebug -I test test/ruby/signature/type_parsing_test.rb

# Running tests with run options --seed 49176:

.........W, [2019-11-10T06:53:52.509785 #3397]  WARN -- ruby-signature: `any` type is deprecated. Use `untyped` instead. (-:1:0...2:0)
...

Finished tests in 0.016869s, 711.3640 tests/s, 12152.4690 assertions/s.

12 tests, 205 assertions, 0 failures, 0 errors, 0 skips
```

## After

```
$ ruby -r bundler/setup -r pry-byebug -I test test/ruby/signature/type_parsing_test.rb
# Running tests with run options --seed 30639:

............

Finished tests in 0.042754s, 280.6735 tests/s, 4794.8393 assertions/s.

12 tests, 205 assertions, 0 failures, 0 errors, 0 skips
```