### PR TITLE
Fix Kernel#p typing

### DIFF
--- a/stdlib/builtin/kernel.rbs
+++ b/stdlib/builtin/kernel.rbs
@@ -412,7 +412,8 @@ module Kernel
 
   def puts: (*untyped arg0) -> NilClass
 
-  def p: (*untyped arg0) -> NilClass
+  def p: [T] (T arg0) -> T
+       | (*untyped arg0) -> Array[untyped]
 
   # If called without an argument, or if `max.to_i.abs == 0`, rand returns
   # a pseudo-random floating point number between 0.0 and 1.0, including 0.0

--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -1,0 +1,12 @@
+class KernelTest < StdlibTest
+  target Kernel
+  using hook.refinement
+
+  def test_p
+    $stdout = StringIO.new
+    p 1
+    p 'a', 2
+  ensure
+    $stdout = STDOUT
+  end
+end


### PR DESCRIPTION
This pull request fixes `Kernel#p` type.
Currently the return value is typed as NilClass, but actually it returns the argument type.


But, I think this proposed type is not the best way. Because it is too loose for multiple arguments.

```ruby
p 1 # => returns `1`, and the type is Integer
p 1, 2 # => returns `[1, 2]`, but the type is Array[untyped]
```


I'm not sure we can write the return value type. But I have a compromise idea with a limited number of arguments.

```
def p: [T] (T arg0) -> T
     | [T, U] (T arg0, U arg1) -> [T, U]
     | [T, U, V] (T arg0, U arg1, V arg2) -> [T, U, V]
     | [T, U, V, W] (T arg0, U arg1, V arg2, W arg3) -> [T, U, V, W]
     | [T, U, V, W, X] (T arg0, U arg1, V arg2, W arg3, X arg4) -> [T, U, V, W, X]
     | [T, U, V, W, X, Y] (T arg0, U arg1, V arg2, W arg3, X arg4, Y arg5) -> [T, U, V, W, X, Y]
     | [T, U, V, W, X, Y, Z] (T arg0, U arg1, V arg2, W arg3, X arg4, Y arg5, Z arg6) -> [T, U, V, W, X, Y, Z]
     | (*untyped arg0) -> Array[untyped]
```

It works correctly if the arguments are less than 8. 

If you'd like the idea, I'll apply it to this pull request. If you have any idea to write the type with a more cool code, please tell me it!


Thanks.