### PR TITLE
Add kTRUE and kFALSE

### DIFF
--- a/lib/ruby/signature/parser.y
+++ b/lib/ruby/signature/parser.y
@@ -4,7 +4,7 @@ class Ruby::Signature::Parser
         tANNOTATION
         tSTRING tSYMBOL tINTEGER tWRITE_ATTR
         kLPAREN kRPAREN kLBRACKET kRBRACKET kLBRACE kRBRACE
-        kVOID kNIL kANY kUNTYPED kTOP kBOT kSELF kSELFQ kINSTANCE kCLASS kBOOL kSINGLETON kTYPE kDEF kMODULE kSUPER
+        kVOID kNIL kTRUE kFALSE kANY kUNTYPED kTOP kBOT kSELF kSELFQ kINSTANCE kCLASS kBOOL kSINGLETON kTYPE kDEF kMODULE kSUPER
         kPRIVATE kPUBLIC kALIAS
         kCOLON kCOLON2 kCOMMA kBAR kAMP kHAT kARROW kQUESTION kEXCLAMATION kSTAR kSTAR2 kFATARROW kEQ kDOT kLT
         kINTERFACE kEND kINCLUDE kEXTEND kATTRREADER kATTRWRITER kATTRACCESSOR tOPERATOR tQUOTEDMETHOD
@@ -502,7 +502,7 @@ rule
   method_name0: tUIDENT | tLIDENT | identifier_keywords
 
   identifier_keywords:
-      kCLASS | kVOID | kNIL | kANY | kUNTYPED | kTOP | kBOT | kINSTANCE | kBOOL | kSINGLETON
+      kCLASS | kVOID | kNIL | kTRUE | kFALSE | kANY | kUNTYPED | kTOP | kBOT | kINSTANCE | kBOOL | kSINGLETON
     | kTYPE | kMODULE | kPRIVATE | kPUBLIC | kEND | kINCLUDE | kEXTEND | kPREPEND
     | kATTRREADER | kATTRACCESSOR | kATTRWRITER | kDEF | kEXTENSION | kSELF | kINCOMPATIBLE
     | kUNCHECKED
@@ -676,6 +676,12 @@ rule
       }
     | kCLASS {
         result = Types::Bases::Class.new(location: val[0].location)
+      }
+    | kTRUE {
+        result = Types::Literal.new(literal: true, location: val[0].location)
+      }
+    | kFALSE {
+        result = Types::Literal.new(literal: false, location: val[0].location)
       }
     | tINTEGER {
         result = Types::Literal.new(literal: val[0].value, location: val[0].location)
@@ -1147,6 +1153,8 @@ KEYWORDS = {
   "instance" => :kINSTANCE,
   "bool" => :kBOOL,
   "nil" => :kNIL,
+  "true" => :kTRUE,
+  "false" => :kFALSE,
   "singleton" => :kSINGLETON,
   "interface" => :kINTERFACE,
   "end" => :kEND,

--- a/stdlib/builtin/nil_class.rbs
+++ b/stdlib/builtin/nil_class.rbs
@@ -1,6 +1,6 @@
 # The class of the singleton object `nil` .
 class NilClass < Object
-  def &: (untyped obj) -> FalseClass
+  def &: (untyped obj) -> false
 
   def ^: (untyped obj) -> bool
 
@@ -45,5 +45,5 @@ class NilClass < Object
   def |: (untyped obj) -> bool
 
   # Only the object *nil* responds `true` to `nil?` .
-  def `nil?`: () -> TrueClass
+  def `nil?`: () -> true
 end

--- a/test/ruby/signature/signature_parsing_test.rb
+++ b/test/ruby/signature/signature_parsing_test.rb
@@ -520,6 +520,8 @@ class Ruby::Signature::SignatureParsingTest < Minitest::Test
         def class: -> String
         def void: -> String
         def nil?: -> String
+        def true: -> untyped
+        def false: -> untyped
         def any: -> String
         def top: -> String
         def bot: -> String
@@ -554,6 +556,8 @@ class Ruby::Signature::SignatureParsingTest < Minitest::Test
         :class,
         :void,
         :nil?,
+        :true,
+        :false,
         :any,
         :top,
         :bot,

--- a/test/stdlib/NilClass_test.rb
+++ b/test/stdlib/NilClass_test.rb
@@ -5,4 +5,12 @@ class NilClassTest < StdlibTest
   def test_to_i
     nil.to_i
   end
+
+  def test_nil?
+    nil.nil?
+  end
+
+  define_method "test_&" do
+    nil & true
+  end
 end


### PR DESCRIPTION
Currently, true and false literals aren't supported despite it's written in our doc.

https://github.com/ruby/ruby-signature/blob/ba26445a4f18c26d140f201896d7d1ace7b3c717/doc/syntax.md#literal-type

I'd like to add kTRUE and kFALSE.