### PR TITLE
Add Regexp_test.rb and update regexp.rbs

### DIFF
--- a/stdlib/builtin/regexp.rbs
+++ b/stdlib/builtin/regexp.rbs
@@ -45,10 +45,10 @@ class Regexp < Object
   # ```
   def inspect: () -> String
 
-  def match: (String arg0, ?Integer arg1) -> MatchData?
-           | (String arg0, ?Integer arg1) { (MatchData) -> untyped } -> untyped
+  def match: (String? | Symbol | _ToStr arg0, ?Integer arg1) -> MatchData?
+           | (String? | Symbol | _ToStr arg0, ?Integer arg1) { (MatchData) -> untyped } -> untyped
 
-  def match?: (String? arg0, ?Integer arg1) -> bool
+  def match?: (String? | Symbol | _ToStr arg0, ?Integer arg1) -> bool
 
   def named_captures: () -> ::Hash[String, ::Array[Integer]]
 

--- a/stdlib/builtin/regexp.rbs
+++ b/stdlib/builtin/regexp.rbs
@@ -107,14 +107,14 @@ class Regexp < Object
 
   def ~: () -> Integer?
 
-  def self.compile: (String arg0, ?untyped options, ?String kcode) -> self
-                  | (Regexp arg0) -> self
+  def self.compile: (String arg0, ?untyped options, ?String kcode) -> Regexp
+                  | (Regexp arg0) -> Regexp
 
   def self.quote: (String | Symbol arg0) -> String
 
-  def self.union: () -> self
-                | (String | Regexp arg0, *String | Regexp args) -> self
-                | (::Array[String | Regexp]) -> self
+  def self.union: () -> Regexp
+                | (String | Regexp arg0, *String | Regexp args) -> Regexp
+                | (::Array[String | Regexp]) -> Regexp
 
   def eql?: (untyped other) -> bool
 end

--- a/stdlib/builtin/regexp.rbs
+++ b/stdlib/builtin/regexp.rbs
@@ -2,7 +2,8 @@ class Regexp < Object
   def self.escape: (String | Symbol arg0) -> String
 
   def self.last_match: () -> MatchData
-                     | (?Integer arg0) -> String
+                     | (Integer n) -> String?
+                     | (Symbol | String n) -> String
 
   def self.try_convert: (untyped obj) -> Regexp?
 
@@ -13,7 +14,7 @@ class Regexp < Object
   def =~: (String? str) -> Integer?
 
   # Returns the value of the case-insensitive flag.
-  # 
+  #
   # ```ruby
   # /a/.casefold?           #=> false
   # /a/i.casefold?          #=> true
@@ -28,7 +29,7 @@ class Regexp < Object
   def fixed_encoding?: () -> bool
 
   # Produce a hash based on the text and options of this regular expression.
-  # 
+  #
   # See also Object\#hash.
   def hash: () -> Integer
 
@@ -38,13 +39,15 @@ class Regexp < Object
   # Produce a nicely formatted string-version of *rxp* . Perhaps
   # surprisingly, `#inspect` actually produces the more natural version of
   # the string than `#to_s` .
-  # 
+  #
   # ```ruby
   # /ab+c/ix.inspect        #=> "/ab+c/ix"
   # ```
   def inspect: () -> String
 
   def match: (String? arg0, ?Integer arg1) -> MatchData?
+
+  def match?: (String? arg0, ?Integer arg1) -> bool
 
   def named_captures: () -> ::Hash[String, ::Array[Integer]]
 
@@ -55,30 +58,30 @@ class Regexp < Object
   # details. Note that additional bits may be set in the returned options:
   # these are used internally by the regular expression code. These extra
   # bits are ignored if the options are passed to `Regexp::new` .
-  # 
+  #
   # ```ruby
   # Regexp::IGNORECASE                  #=> 1
   # Regexp::EXTENDED                    #=> 2
   # Regexp::MULTILINE                   #=> 4
-  # 
+  #
   # /cat/.options                       #=> 0
   # /cat/ix.options                     #=> 3
   # Regexp.new('cat', true).options     #=> 1
   # /\xa1\xa2/e.options                 #=> 16
-  # 
+  #
   # r = /cat/ix
   # Regexp.new(r.source, r.options)     #=> /cat/ix
   # ```
   def options: () -> Integer
 
   # Returns the original string of the pattern.
-  # 
+  #
   # ```ruby
   # /ab+c/ix.source #=> "ab+c"
   # ```
-  # 
+  #
   # Note that escape sequences are retained as is.
-  # 
+  #
   # ```ruby
   # /\x20\+/.source  #=> "\\x20\\+"
   # ```
@@ -91,7 +94,7 @@ class Regexp < Object
   # two, as the source of the regular expression itself may differ, as the
   # example shows). `Regexp#inspect` produces a generally more readable
   # version of *rxp* .
-  # 
+  #
   # ```ruby
   # r1 = /ab+c/ix           #=> /ab+c/ix
   # s1 = r1.to_s            #=> "(?ix-m:ab+c)"
@@ -108,6 +111,10 @@ class Regexp < Object
                   | (Regexp arg0) -> self
 
   def self.quote: (String | Symbol arg0) -> String
+
+  def self.union: () -> self
+                | (String | Regexp arg0, *String | Regexp args) -> self
+                | (::Array[String | Regexp]) -> self
 
   def eql?: (untyped other) -> bool
 end

--- a/stdlib/builtin/regexp.rbs
+++ b/stdlib/builtin/regexp.rbs
@@ -45,7 +45,8 @@ class Regexp < Object
   # ```
   def inspect: () -> String
 
-  def match: (String? arg0, ?Integer arg1) -> MatchData?
+  def match: (String arg0, ?Integer arg1) -> MatchData?
+           | (String arg0, ?Integer arg1) { (MatchData) -> untyped } -> untyped
 
   def match?: (String? arg0, ?Integer arg1) -> bool
 

--- a/test/stdlib/Regexp_test.rb
+++ b/test/stdlib/Regexp_test.rb
@@ -1,0 +1,144 @@
+class RegexpTest < StdlibTest
+  target Regexp
+  using hook.refinement
+
+  def test_new
+    r1 = Regexp.new('^a-z+:\\s+\w+') #=> /^a-z+:\s+\w+/
+    r2 = Regexp.new('cat', true)     #=> /cat/i
+    r3 = Regexp.new(r2)              #=> /cat/i
+    r4 = Regexp.new('dog', Regexp::EXTENDED | Regexp::IGNORECASE) #=> /dog/ix
+  end
+
+  def test_escape
+    Regexp.escape('\*?{}.')
+  end
+
+  def test_try_convert
+    Regexp.try_convert(/re/)    #=> /re/
+    Regexp.try_convert("re")    #=> nil
+
+    o = Object.new
+    Regexp.try_convert(o)       #=> nil
+    def o.to_regexp() /foo/ end
+    Regexp.try_convert(o)       #=> /foo/
+  end
+
+  def test_compile
+    r1 = Regexp.compile('^a-z+:\\s+\w+') #=> /^a-z+:\s+\w+/
+    r2 = Regexp.compile('cat', true)     #=> /cat/i
+    r3 = Regexp.compile(r2)              #=> /cat/i
+    r4 = Regexp.compile('dog', Regexp::EXTENDED | Regexp::IGNORECASE) #=> /dog/ix
+  end
+
+  def test_quote
+    Regexp.quote('\*?{}.')
+  end
+
+  def test_union
+    Regexp.union                              #=> /(?!)/
+    Regexp.union("penzance")                  #=> /penzance/
+    Regexp.union("a+b*c")                     #=> /a\+b\*c/
+    Regexp.union("skiing", "sledding")        #=> /skiing|sledding/
+    Regexp.union("skiing", "sledding", "sky") #=> /skiing|sledding/
+    Regexp.union(["skiing", "sledding"])      #=> /skiing|sledding/
+    Regexp.union(/dogs/, /cats/i)             #=> /(?-mix:dogs)|(?i-mx:cats)/
+    Regexp.union("dogs", /cats/i)             #=> /dogs|(?i-mx:cats)/
+    Regexp.union(["dogs", /cats/i])           #=> /dogs|(?i-mx:cats)/
+  end
+
+  # test_==
+  def test_double_equal
+    /abc/  == /abc/x #=> false
+    /abc/  == /abc/i #=> false
+    /abc/  == /abc/u #=> false
+    /abc/u == /abc/n #=> false
+  end
+
+  # test_===
+  def test_triple_equal
+    a = "HELLO"
+    if (/\A[a-z]*\z/ === a)
+      "Lower case\n"
+    elsif (/\A[A-Z]*\z/ === a)
+      "Upper case\n"
+    else
+      "Mixed case\n"
+    end
+    #=> "Upper case"
+  end
+
+  # test_=~
+  def test_equal_tilde
+    /at/ =~ "input data" #=> 7
+    /ax/ =~ "input data" #=> nil
+  end
+
+  def test_casefold?
+    /a/.casefold?      #=> false
+    /a/i.casefold?     #=> true
+    /(?i:a)/.casefold? #=> false
+  end
+
+  def test_encoding
+    /(?i:a)/.encoding
+  end
+
+  def test_fixed_encoding?
+    /a/.fixed_encoding?  #=> false
+    /a/u.fixed_encoding? #=> true
+  end
+
+  def test_hash
+    /a/.hash
+  end
+
+  def test_inspect
+    /ab+c/ix.inspect #=> "/ab+c/ix"
+  end
+
+  def test_match
+    /(.)(.)(.)/.match("abc")[2] #=> "b"
+    /(.)(.)/.match("abc", 1)[2] #=> "c"
+  end
+
+  def test_match?
+    /R.../.match?("Ruby")    #=> true
+    /R.../.match?("Ruby", 1) #=> false
+    /P.../.match?("Ruby")    #=> false
+  end
+
+  def test_named_captures
+    /(?<foo>.)(?<bar>.)/.named_captures #=> {"foo"=>[1], "bar"=>[2]}
+    /(?<foo>.)(?<foo>.)/.named_captures #=> {"foo"=>[1, 2]}
+    /(.)(.)/.named_captures             #=> {}
+  end
+
+  def test_names
+    /(?<foo>.)(?<bar>.)(?<baz>.)/.names #=> ["foo", "bar", "baz"]
+    /(?<foo>.)(?<foo>.)/.names          #=> ["foo"]
+    /(.)(.)/.names                      #=> []
+  end
+
+  def test_options
+    /cat/.options                   #=> 0
+    /cat/ix.options                 #=> 3
+    Regexp.new('cat', true).options #=> 1
+    /\xa1\xa2/e.options             #=> 16
+  end
+
+  def test_source
+    /ab+c/ix.source #=> "ab+c"
+    /\x20\+/.source #=> "\\x20\\+"
+  end
+
+  def test_to_s
+    /ab+c/ix.to_s #=> "(?ix-m:ab+c)"
+  end
+
+  def test_eql?
+    /abc/.eql?(/abc/x)  #=> false
+    /abc/.eql?(/abc/i)  #=> false
+    /abc/.eql?(/abc/u)  #=> false
+    /abc/u.eql?(/abc/n) #=> false
+  end
+end

--- a/test/stdlib/Regexp_test.rb
+++ b/test/stdlib/Regexp_test.rb
@@ -97,8 +97,15 @@ class RegexpTest < StdlibTest
   end
 
   def test_match
-    /(.)(.)(.)/.match("abc")[2] #=> "b"
-    /(.)(.)/.match("abc", 1)[2] #=> "c"
+    /(.)(.)(.)/.match("abc") #=> MatchData
+    /(.)(.)/.match("abc", 1) #=> MatchData
+    /b/.match("a")           #=> nil
+    /M(.*)/.match("Matz") do |m|
+      # nop
+    end
+    /M(.*)/.match("Matz", 1) do |m|
+      # nop
+    end
   end
 
   def test_match?

--- a/test/stdlib/Regexp_test.rb
+++ b/test/stdlib/Regexp_test.rb
@@ -97,9 +97,13 @@ class RegexpTest < StdlibTest
   end
 
   def test_match
-    /(.)(.)(.)/.match("abc") #=> MatchData
-    /(.)(.)/.match("abc", 1) #=> MatchData
-    /b/.match("a")           #=> nil
+    /R.../.match("Ruby")    #=> MatchData
+    /P.../.match("Ruby")    #=> nil
+    /R.../.match(:Ruby)     #=> MatchData
+    /R.../.match(nil)       #=> nil
+    o = Class.new { def to_str; "object"; end }.new
+    /R.../.match(o)         #=> nil
+    /R.../.match("Ruby", 1) #=> nil
     /M(.*)/.match("Matz") do |m|
       # nop
     end
@@ -110,8 +114,12 @@ class RegexpTest < StdlibTest
 
   def test_match?
     /R.../.match?("Ruby")    #=> true
-    /R.../.match?("Ruby", 1) #=> false
     /P.../.match?("Ruby")    #=> false
+    /R.../.match?(:Ruby)     #=> true
+    /R.../.match?(nil)       #=> false
+    o = Class.new { def to_str; "object"; end }.new
+    /R.../.match?(o)         #=> false
+    /R.../.match?("Ruby", 1) #=> false
   end
 
   def test_named_captures


### PR DESCRIPTION
## WHY
There is no test in regexp.rbs and some method signatures (`Regexp::union`, `Regexp#match?`) are not written in it.

I want to contribute to ruby-signatures by writing tests and updating regexp.rbs.

## WHAT
Updated regexp.rbs and added Regexp_test.rb.
I referred to [ruby-doc of Regexp](https://ruby-doc.org/core-2.6.5/Regexp.html) when writing the tests.

### regexp.rbs
Added two signatures of methods.

- ::union
- #match?

Updated signatures of followings.

- ::last_match
  - I referenced [ruby-doc of Regexp](https://ruby-doc.org/core-2.6.5/Regexp.html#method-c-last_match) to update this.
- #match
  - I referenced [ruby-doc of Regexp](https://ruby-doc.org/core-2.6.5/Regexp.html#method-i-match) to update this.

### Regexp_test.rb
Added following tests.

- #new
- ::escape
- ::try_convert
- ::compile
- ::quote
- ::union
- #==
- #===
- #=~
- #casefold?
- #encoding
- #fixed_encoding?
- #hash
- #inspect
- #match
- #match?
- #named_captures
- #names
- #options
- #source
- #to_s
- #eql?

But, `::last_match` and `#~` are difficult to write tests, so I left them as future works.

### How I tested
I tested with `$ RBS_TEST_LOGLEVEL=debug RBS_TEST_TARGET='Regexp' bundle exec ruby bin/test_runner.rb Regexp` .

<details>

```console
$ RBS_TEST_LOGLEVEL=debug RBS_TEST_TARGET='Regexp' bundle exec ruby bin/test_runner.rb Regexp
I, [2019-11-11T14:19:41.735219 #37643]  INFO -- : Installing a hook on ::Regexp#==: (untyped other) -> bool
I, [2019-11-11T14:19:41.735341 #37643]  INFO -- : Installing a hook on ::Regexp#initialize: (::String arg0, ?untyped options, ?::String kcode) -> ::Object | (::Regexp arg0) -> void
I, [2019-11-11T14:19:41.735401 #37643]  INFO -- : Installing a hook on ::Regexp#===: (untyped other) -> bool
I, [2019-11-11T14:19:41.735427 #37643]  INFO -- : Installing a hook on ::Regexp#=~: (::String? str) -> ::Integer?
I, [2019-11-11T14:19:41.735462 #37643]  INFO -- : Installing a hook on ::Regexp#eql?: (untyped other) -> bool
I, [2019-11-11T14:19:41.735493 #37643]  INFO -- : Installing a hook on ::Regexp#hash: () -> ::Integer
I, [2019-11-11T14:19:41.735517 #37643]  INFO -- : Installing a hook on ::Regexp#inspect: () -> ::String
I, [2019-11-11T14:19:41.735653 #37643]  INFO -- : Installing a hook on ::Regexp#to_s: () -> ::String
I, [2019-11-11T14:19:41.735926 #37643]  INFO -- : Installing a hook on ::Regexp#casefold?: () -> bool
I, [2019-11-11T14:19:41.735976 #37643]  INFO -- : Installing a hook on ::Regexp#encoding: () -> ::Encoding
I, [2019-11-11T14:19:41.736016 #37643]  INFO -- : Installing a hook on ::Regexp#fixed_encoding?: () -> bool
I, [2019-11-11T14:19:41.736096 #37643]  INFO -- : Installing a hook on ::Regexp#match: (::String arg0, ?::Integer arg1) -> ::MatchData? | (::String arg0, ?::Integer arg1) { (::MatchData) -> untyped } -> untyped
I, [2019-11-11T14:19:41.736194 #37643]  INFO -- : Installing a hook on ::Regexp#match?: (::String? arg0, ?::Integer arg1) -> bool
I, [2019-11-11T14:19:41.736290 #37643]  INFO -- : Installing a hook on ::Regexp#named_captures: () -> ::Hash[::String, ::Array[::Integer]]
I, [2019-11-11T14:19:41.736339 #37643]  INFO -- : Installing a hook on ::Regexp#names: () -> ::Array[::String]
I, [2019-11-11T14:19:41.736393 #37643]  INFO -- : Installing a hook on ::Regexp#options: () -> ::Integer
I, [2019-11-11T14:19:41.736444 #37643]  INFO -- : Installing a hook on ::Regexp#source: () -> ::String
I, [2019-11-11T14:19:41.736494 #37643]  INFO -- : Installing a hook on ::Regexp#~: () -> ::Integer?
I, [2019-11-11T14:19:41.752777 #37643]  INFO -- : Installing a hook on ::Regexp.new: (::String arg0, ?untyped options, ?::String kcode) -> ::Regexp | (::Regexp arg0) -> ::Regexp
I, [2019-11-11T14:19:41.752875 #37643]  INFO -- : Installing a hook on ::Regexp.escape: (::String | ::Symbol arg0) -> ::String
I, [2019-11-11T14:19:41.752935 #37643]  INFO -- : Installing a hook on ::Regexp.last_match: () -> ::MatchData | (::Integer n) -> ::String? | (::Symbol | ::String n) -> ::String
I, [2019-11-11T14:19:41.752974 #37643]  INFO -- : Installing a hook on ::Regexp.try_convert: (untyped obj) -> ::Regexp?
I, [2019-11-11T14:19:41.753022 #37643]  INFO -- : Installing a hook on ::Regexp.compile: (::String arg0, ?untyped options, ?::String kcode) -> ::Regexp | (::Regexp arg0) -> ::Regexp
I, [2019-11-11T14:19:41.753062 #37643]  INFO -- : Installing a hook on ::Regexp.quote: (::String | ::Symbol arg0) -> ::String
I, [2019-11-11T14:19:41.753126 #37643]  INFO -- : Installing a hook on ::Regexp.union: () -> ::Regexp | (::String | ::Regexp arg0, *::String | ::Regexp args) -> ::Regexp | (::Array[::String | ::Regexp]) -> ::Regexp
Run options: --seed 55496

# Running:

D, [2019-11-11T14:19:41.762415 #37643] DEBUG -- : #to_s receives arguments: []
D, [2019-11-11T14:19:41.762477 #37643] DEBUG -- : #to_s returns: "(?ix-m:ab+c)"
.D, [2019-11-11T14:19:41.762707 #37643] DEBUG -- : .compile receives arguments: ["^a-z+:\\s+\\w+"]
D, [2019-11-11T14:19:41.762840 #37643] DEBUG -- : .compile returns: /^a-z+:\s+\w+/
D, [2019-11-11T14:19:41.762996 #37643] DEBUG -- : .compile receives arguments: ["cat", true]
D, [2019-11-11T14:19:41.763027 #37643] DEBUG -- : .compile returns: /cat/i
D, [2019-11-11T14:19:41.763248 #37643] DEBUG -- : .compile receives arguments: [/cat/i]
D, [2019-11-11T14:19:41.763371 #37643] DEBUG -- : .compile returns: /cat/i
D, [2019-11-11T14:19:41.763572 #37643] DEBUG -- : .compile receives arguments: ["dog", 3]
D, [2019-11-11T14:19:41.763680 #37643] DEBUG -- : .compile returns: /dog/ix
.D, [2019-11-11T14:19:41.764359 #37643] DEBUG -- : #== receives arguments: [/abc/x]
D, [2019-11-11T14:19:41.764543 #37643] DEBUG -- : #== returns: false
D, [2019-11-11T14:19:41.764606 #37643] DEBUG -- : #== receives arguments: [/abc/i]
D, [2019-11-11T14:19:41.764688 #37643] DEBUG -- : #== returns: false
D, [2019-11-11T14:19:41.764951 #37643] DEBUG -- : #== receives arguments: [/abc/]
D, [2019-11-11T14:19:41.765024 #37643] DEBUG -- : #== returns: false
D, [2019-11-11T14:19:41.765196 #37643] DEBUG -- : #== receives arguments: [/abc/n]
D, [2019-11-11T14:19:41.765260 #37643] DEBUG -- : #== returns: false
.D, [2019-11-11T14:19:41.765441 #37643] DEBUG -- : #hash receives arguments: []
D, [2019-11-11T14:19:41.765499 #37643] DEBUG -- : #hash returns: 1190721837341369078
.D, [2019-11-11T14:19:41.765663 #37643] DEBUG -- : #eql? receives arguments: [/abc/x]
D, [2019-11-11T14:19:41.765713 #37643] DEBUG -- : #eql? returns: false
D, [2019-11-11T14:19:41.765838 #37643] DEBUG -- : #eql? receives arguments: [/abc/i]
D, [2019-11-11T14:19:41.765910 #37643] DEBUG -- : #eql? returns: false
D, [2019-11-11T14:19:41.765996 #37643] DEBUG -- : #eql? receives arguments: [/abc/]
D, [2019-11-11T14:19:41.766059 #37643] DEBUG -- : #eql? returns: false
D, [2019-11-11T14:19:41.766130 #37643] DEBUG -- : #eql? receives arguments: [/abc/n]
D, [2019-11-11T14:19:41.766204 #37643] DEBUG -- : #eql? returns: false
.D, [2019-11-11T14:19:41.766420 #37643] DEBUG -- : #match receives arguments: ["abc"]
D, [2019-11-11T14:19:41.766726 #37643] DEBUG -- : #match returns: #<MatchData "abc" 1:"a" 2:"b" 3:"c">
D, [2019-11-11T14:19:41.767036 #37643] DEBUG -- : #match receives arguments: ["abc", 1]
D, [2019-11-11T14:19:41.767160 #37643] DEBUG -- : #match returns: #<MatchData "bc" 1:"b" 2:"c">
D, [2019-11-11T14:19:41.767441 #37643] DEBUG -- : #match receives arguments: ["a"]
D, [2019-11-11T14:19:41.767543 #37643] DEBUG -- : #match returns: nil
D, [2019-11-11T14:19:41.767743 #37643] DEBUG -- : #match receives arguments: ["Matz"]
D, [2019-11-11T14:19:41.767921 #37643] DEBUG -- : #match receives block arguments: [#<MatchData "Matz" 1:"atz">]
D, [2019-11-11T14:19:41.768014 #37643] DEBUG -- : #match returns from block: nil
D, [2019-11-11T14:19:41.768071 #37643] DEBUG -- : #match returns: nil
D, [2019-11-11T14:19:41.768325 #37643] DEBUG -- : #match receives arguments: ["Matz", 1]
D, [2019-11-11T14:19:41.768450 #37643] DEBUG -- : #match returns: nil
.D, [2019-11-11T14:19:41.768832 #37643] DEBUG -- : .quote receives arguments: ["\\*?{}."]
D, [2019-11-11T14:19:41.768863 #37643] DEBUG -- : .quote returns: "\\\\\\*\\?\\{\\}\\."
.D, [2019-11-11T14:19:41.769001 #37643] DEBUG -- : #named_captures receives arguments: []
D, [2019-11-11T14:19:41.769042 #37643] DEBUG -- : #named_captures returns: {"foo"=>[1], "bar"=>[2]}
D, [2019-11-11T14:19:41.769099 #37643] DEBUG -- : #named_captures receives arguments: []
D, [2019-11-11T14:19:41.769128 #37643] DEBUG -- : #named_captures returns: {"foo"=>[1, 2]}
D, [2019-11-11T14:19:41.769166 #37643] DEBUG -- : #named_captures receives arguments: []
D, [2019-11-11T14:19:41.769187 #37643] DEBUG -- : #named_captures returns: {}
.D, [2019-11-11T14:19:41.769249 #37643] DEBUG -- : .new receives arguments: ["^a-z+:\\s+\\w+"]
D, [2019-11-11T14:19:41.769299 #37643] DEBUG -- : .new returns: /^a-z+:\s+\w+/
D, [2019-11-11T14:19:41.769344 #37643] DEBUG -- : .new receives arguments: ["cat", true]
D, [2019-11-11T14:19:41.769364 #37643] DEBUG -- : .new returns: /cat/i
D, [2019-11-11T14:19:41.769403 #37643] DEBUG -- : .new receives arguments: [/cat/i]
D, [2019-11-11T14:19:41.769420 #37643] DEBUG -- : .new returns: /cat/i
D, [2019-11-11T14:19:41.769451 #37643] DEBUG -- : .new receives arguments: ["dog", 3]
D, [2019-11-11T14:19:41.769468 #37643] DEBUG -- : .new returns: /dog/ix
.D, [2019-11-11T14:19:41.769528 #37643] DEBUG -- : #names receives arguments: []
D, [2019-11-11T14:19:41.769547 #37643] DEBUG -- : #names returns: ["foo", "bar", "baz"]
D, [2019-11-11T14:19:41.769570 #37643] DEBUG -- : #names receives arguments: []
D, [2019-11-11T14:19:41.769585 #37643] DEBUG -- : #names returns: ["foo"]
D, [2019-11-11T14:19:41.769605 #37643] DEBUG -- : #names receives arguments: []
D, [2019-11-11T14:19:41.769618 #37643] DEBUG -- : #names returns: []
.D, [2019-11-11T14:19:41.769660 #37643] DEBUG -- : .try_convert receives arguments: [/re/]
D, [2019-11-11T14:19:41.769675 #37643] DEBUG -- : .try_convert returns: /re/
D, [2019-11-11T14:19:41.769699 #37643] DEBUG -- : .try_convert receives arguments: ["re"]
D, [2019-11-11T14:19:41.769714 #37643] DEBUG -- : .try_convert returns: nil
D, [2019-11-11T14:19:41.769736 #37643] DEBUG -- : .try_convert receives arguments: [#<Object:0x00007fb106efdb48>]
D, [2019-11-11T14:19:41.769750 #37643] DEBUG -- : .try_convert returns: nil
D, [2019-11-11T14:19:41.769774 #37643] DEBUG -- : .try_convert receives arguments: [#<Object:0x00007fb106efdb48>]
D, [2019-11-11T14:19:41.769789 #37643] DEBUG -- : .try_convert returns: /foo/
..D, [2019-11-11T14:19:41.769858 #37643] DEBUG -- : #casefold? receives arguments: []
D, [2019-11-11T14:19:41.769874 #37643] DEBUG -- : #casefold? returns: false
D, [2019-11-11T14:19:41.769889 #37643] DEBUG -- : #casefold? receives arguments: []
D, [2019-11-11T14:19:41.769901 #37643] DEBUG -- : #casefold? returns: true
D, [2019-11-11T14:19:41.769913 #37643] DEBUG -- : #casefold? receives arguments: []
D, [2019-11-11T14:19:41.769924 #37643] DEBUG -- : #casefold? returns: false
.D, [2019-11-11T14:19:41.769958 #37643] DEBUG -- : .union receives arguments: []
D, [2019-11-11T14:19:41.770010 #37643] DEBUG -- : .union returns: /(?!)/
D, [2019-11-11T14:19:41.770043 #37643] DEBUG -- : .union receives arguments: ["penzance"]
D, [2019-11-11T14:19:41.770061 #37643] DEBUG -- : .union returns: /penzance/
D, [2019-11-11T14:19:41.770100 #37643] DEBUG -- : .union receives arguments: ["a+b*c"]
D, [2019-11-11T14:19:41.770125 #37643] DEBUG -- : .union returns: /a\+b\*c/
D, [2019-11-11T14:19:41.770162 #37643] DEBUG -- : .union receives arguments: ["skiing", "sledding"]
D, [2019-11-11T14:19:41.770183 #37643] DEBUG -- : .union returns: /skiing|sledding/
D, [2019-11-11T14:19:41.770225 #37643] DEBUG -- : .union receives arguments: ["skiing", "sledding", "sky"]
D, [2019-11-11T14:19:41.770247 #37643] DEBUG -- : .union returns: /skiing|sledding|sky/
D, [2019-11-11T14:19:41.770289 #37643] DEBUG -- : .union receives arguments: [["skiing", "sledding"]]
D, [2019-11-11T14:19:41.770309 #37643] DEBUG -- : .union returns: /skiing|sledding/
D, [2019-11-11T14:19:41.770354 #37643] DEBUG -- : .union receives arguments: [/dogs/, /cats/i]
D, [2019-11-11T14:19:41.770377 #37643] DEBUG -- : .union returns: /(?-mix:dogs)|(?i-mx:cats)/
D, [2019-11-11T14:19:41.770419 #37643] DEBUG -- : .union receives arguments: ["dogs", /cats/i]
D, [2019-11-11T14:19:41.770440 #37643] DEBUG -- : .union returns: /dogs|(?i-mx:cats)/
D, [2019-11-11T14:19:41.770481 #37643] DEBUG -- : .union receives arguments: [["dogs", /cats/i]]
D, [2019-11-11T14:19:41.770502 #37643] DEBUG -- : .union returns: /dogs|(?i-mx:cats)/
.D, [2019-11-11T14:19:41.770575 #37643] DEBUG -- : #=== receives arguments: ["HELLO"]
D, [2019-11-11T14:19:41.770593 #37643] DEBUG -- : #=== returns: false
D, [2019-11-11T14:19:41.770613 #37643] DEBUG -- : #=== receives arguments: ["HELLO"]
D, [2019-11-11T14:19:41.770627 #37643] DEBUG -- : #=== returns: true
.D, [2019-11-11T14:19:41.770666 #37643] DEBUG -- : #encoding receives arguments: []
D, [2019-11-11T14:19:41.770684 #37643] DEBUG -- : #encoding returns: #<Encoding:US-ASCII>
.D, [2019-11-11T14:19:41.770724 #37643] DEBUG -- : #inspect receives arguments: []
D, [2019-11-11T14:19:41.770739 #37643] DEBUG -- : #inspect returns: "/ab+c/ix"
.D, [2019-11-11T14:19:41.770782 #37643] DEBUG -- : #fixed_encoding? receives arguments: []
D, [2019-11-11T14:19:41.770796 #37643] DEBUG -- : #fixed_encoding? returns: false
D, [2019-11-11T14:19:41.770810 #37643] DEBUG -- : #fixed_encoding? receives arguments: []
D, [2019-11-11T14:19:41.770822 #37643] DEBUG -- : #fixed_encoding? returns: true
.D, [2019-11-11T14:19:41.770857 #37643] DEBUG -- : .escape receives arguments: ["\\*?{}."]
D, [2019-11-11T14:19:41.770871 #37643] DEBUG -- : .escape returns: "\\\\\\*\\?\\{\\}\\."
.D, [2019-11-11T14:19:41.770916 #37643] DEBUG -- : #options receives arguments: []
D, [2019-11-11T14:19:41.770931 #37643] DEBUG -- : #options returns: 0
D, [2019-11-11T14:19:41.770948 #37643] DEBUG -- : #options receives arguments: []
D, [2019-11-11T14:19:41.770960 #37643] DEBUG -- : #options returns: 3
D, [2019-11-11T14:19:41.770976 #37643] DEBUG -- : .new receives arguments: ["cat", true]
D, [2019-11-11T14:19:41.770992 #37643] DEBUG -- : .new returns: /cat/i
D, [2019-11-11T14:19:41.771029 #37643] DEBUG -- : #options receives arguments: []
D, [2019-11-11T14:19:41.771042 #37643] DEBUG -- : #options returns: 1
D, [2019-11-11T14:19:41.771057 #37643] DEBUG -- : #options receives arguments: []
D, [2019-11-11T14:19:41.771069 #37643] DEBUG -- : #options returns: 16
.D, [2019-11-11T14:19:41.771107 #37643] DEBUG -- : #match? receives arguments: ["Ruby"]
D, [2019-11-11T14:19:41.771122 #37643] DEBUG -- : #match? returns: true
D, [2019-11-11T14:19:41.771146 #37643] DEBUG -- : #match? receives arguments: ["Ruby", 1]
D, [2019-11-11T14:19:41.771159 #37643] DEBUG -- : #match? returns: false
D, [2019-11-11T14:19:41.771184 #37643] DEBUG -- : #match? receives arguments: ["Ruby"]
D, [2019-11-11T14:19:41.771197 #37643] DEBUG -- : #match? returns: false
.D, [2019-11-11T14:19:41.771241 #37643] DEBUG -- : #source receives arguments: []
D, [2019-11-11T14:19:41.771255 #37643] DEBUG -- : #source returns: "ab+c"
D, [2019-11-11T14:19:41.771271 #37643] DEBUG -- : #source receives arguments: []
D, [2019-11-11T14:19:41.771283 #37643] DEBUG -- : #source returns: "\\x20\\+"
.

Finished in 0.009958s, 2209.2790 runs/s, 4418.5579 assertions/s.

22 runs, 44 assertions, 0 failures, 0 errors, 0 skips
```

</details>

## Future Work

`::last_match` and `#~` depend on the global variables, so they are difficult to test. I left them as future works.

I tried the following code, and they failed unexpectedly. `Regexp::last_match` depends on `$~` and `Regexp#~` depends on `$_`, I think it's the reason why they failed.

### test code

<details>

```ruby
class RegexpTest < StdlibTest
  target Regexp
  using hook.refinement

  def test_last_match
    /c(.)t/ =~ 'cat'        #=> 0
    Regexp.last_match       #=> #<MatchData "cat" 1:"a">
    Regexp.last_match(0)    #=> "cat"
    Regexp.last_match(1)    #=> "a"
    Regexp.last_match(2)    #=> nil

    /(?<lhs>\w+)\s*=\s*(?<rhs>\w+)/ =~ "var = val"
    Regexp.last_match       #=> #<MatchData "var = val" lhs:"var" rhs:"val">
    Regexp.last_match(:lhs) #=> "var"
    Regexp.last_match(:rhs) #=> "val"
  end

  # test_~
  def test_tilde
    $_ = "input data"
    ~ /at/   #=> 7
  end
end
```

</details>

### log

<details>

```console
$ RBS_TEST_LOGLEVEL=debug RBS_TEST_TARGET='Regexp' bundle exec ruby bin/test_runner.rb Regexp
I, [2019-11-10T20:16:07.296352 #82186]  INFO -- : Installing a hook on ::Regexp#==: (untyped other) -> bool
I, [2019-11-10T20:16:07.296480 #82186]  INFO -- : Installing a hook on ::Regexp#initialize: (::String arg0, ?untyped options, ?::String kcode) -> ::Object | (::Regexp arg0) -> void
I, [2019-11-10T20:16:07.296541 #82186]  INFO -- : Installing a hook on ::Regexp#===: (untyped other) -> bool
I, [2019-11-10T20:16:07.296569 #82186]  INFO -- : Installing a hook on ::Regexp#=~: (::String? str) -> ::Integer?
I, [2019-11-10T20:16:07.296604 #82186]  INFO -- : Installing a hook on ::Regexp#eql?: (untyped other) -> bool
I, [2019-11-10T20:16:07.296636 #82186]  INFO -- : Installing a hook on ::Regexp#hash: () -> ::Integer
I, [2019-11-10T20:16:07.296660 #82186]  INFO -- : Installing a hook on ::Regexp#inspect: () -> ::String
I, [2019-11-10T20:16:07.296739 #82186]  INFO -- : Installing a hook on ::Regexp#to_s: () -> ::String
I, [2019-11-10T20:16:07.296894 #82186]  INFO -- : Installing a hook on ::Regexp#casefold?: () -> bool
I, [2019-11-10T20:16:07.296919 #82186]  INFO -- : Installing a hook on ::Regexp#encoding: () -> ::Encoding
I, [2019-11-10T20:16:07.296941 #82186]  INFO -- : Installing a hook on ::Regexp#fixed_encoding?: () -> bool
I, [2019-11-10T20:16:07.296966 #82186]  INFO -- : Installing a hook on ::Regexp#match: (::String? arg0, ?::Integer arg1) -> ::MatchData?
I, [2019-11-10T20:16:07.297007 #82186]  INFO -- : Installing a hook on ::Regexp#match?: (::String? arg0, ?::Integer arg1) -> bool
I, [2019-11-10T20:16:07.297063 #82186]  INFO -- : Installing a hook on ::Regexp#named_captures: () -> ::Hash[::String, ::Array[::Integer]]
I, [2019-11-10T20:16:07.297143 #82186]  INFO -- : Installing a hook on ::Regexp#names: () -> ::Array[::String]
I, [2019-11-10T20:16:07.297186 #82186]  INFO -- : Installing a hook on ::Regexp#options: () -> ::Integer
I, [2019-11-10T20:16:07.297224 #82186]  INFO -- : Installing a hook on ::Regexp#source: () -> ::String
I, [2019-11-10T20:16:07.297262 #82186]  INFO -- : Installing a hook on ::Regexp#~: () -> ::Integer?
I, [2019-11-10T20:16:07.306099 #82186]  INFO -- : Installing a hook on ::Regexp.new: (::String arg0, ?untyped options, ?::String kcode) -> ::Regexp | (::Regexp arg0) -> ::Regexp
I, [2019-11-10T20:16:07.306170 #82186]  INFO -- : Installing a hook on ::Regexp.escape: (::String | ::Symbol arg0) -> ::String
I, [2019-11-10T20:16:07.306211 #82186]  INFO -- : Installing a hook on ::Regexp.last_match: () -> ::MatchData | (?::Integer arg0) -> ::String | (?::Integer arg0) -> ::NilClass | (?::Symbol | ::String arg0) -> ::String
I, [2019-11-10T20:16:07.306237 #82186]  INFO -- : Installing a hook on ::Regexp.try_convert: (untyped obj) -> ::Regexp?
I, [2019-11-10T20:16:07.306268 #82186]  INFO -- : Installing a hook on ::Regexp.compile: (::String arg0, ?untyped options, ?::String kcode) -> self | (::Regexp arg0) -> self
I, [2019-11-10T20:16:07.306296 #82186]  INFO -- : Installing a hook on ::Regexp.quote: (::String | ::Symbol arg0) -> ::String
I, [2019-11-10T20:16:07.306334 #82186]  INFO -- : Installing a hook on ::Regexp.union: () -> self | (::String | ::Regexp arg0, *::String | ::Regexp args) -> self | (::Array[::String | ::Regexp]) -> self
Run options: --seed 48558

# Running:

D, [2019-11-10T20:16:07.314630 #82186] DEBUG -- : #~ receives arguments: []
D, [2019-11-10T20:16:07.314766 #82186] DEBUG -- : #~ returns: nil
.D, [2019-11-10T20:16:07.315256 #82186] DEBUG -- : .last_match receives arguments: []
D, [2019-11-10T20:16:07.315374 #82186] DEBUG -- : .last_match returns: nil
D, [2019-11-10T20:16:07.315505 #82186] DEBUG -- : .last_match receives arguments: [0]
D, [2019-11-10T20:16:07.315535 #82186] DEBUG -- : .last_match returns: nil
D, [2019-11-10T20:16:07.315642 #82186] DEBUG -- : .last_match receives arguments: [1]
D, [2019-11-10T20:16:07.315667 #82186] DEBUG -- : .last_match returns: nil
D, [2019-11-10T20:16:07.315736 #82186] DEBUG -- : .last_match receives arguments: [2]
D, [2019-11-10T20:16:07.315757 #82186] DEBUG -- : .last_match returns: nil
D, [2019-11-10T20:16:07.315831 #82186] DEBUG -- : .last_match receives arguments: []
D, [2019-11-10T20:16:07.315853 #82186] DEBUG -- : .last_match returns: nil
D, [2019-11-10T20:16:07.315891 #82186] DEBUG -- : .last_match receives arguments: [:lhs]
D, [2019-11-10T20:16:07.315908 #82186] DEBUG -- : .last_match returns: nil
E, [2019-11-10T20:16:07.315984 #82186] ERROR -- : [Regexp.last_match] UnresolvedOverloadingError: couldn't find a suitable overloading
D, [2019-11-10T20:16:07.316006 #82186] DEBUG -- : .last_match receives arguments: [:rhs]
D, [2019-11-10T20:16:07.316023 #82186] DEBUG -- : .last_match returns: nil
E, [2019-11-10T20:16:07.316100 #82186] ERROR -- : [Regexp.last_match] UnresolvedOverloadingError: couldn't find a suitable overloading
F

Finished in 0.004082s, 489.9559 runs/s, 979.9118 assertions/s.

  1) Failure:
RegexpTest#test_last_match [bin/test_runner.rb:35]:
Expected ["[Regexp.last_match] UnresolvedOverloadingError: couldn't find a suitable overloading", "[Regexp.last_match] UnresolvedOverloadingError: couldn't find a suitable overloading"] to be empty.

2 runs, 4 assertions, 1 failures, 0 errors, 0 skips
```

</details>