### PR TITLE
 Add test and update types for Kernel

### DIFF
--- a/stdlib/builtin/kernel.rbs
+++ b/stdlib/builtin/kernel.rbs
@@ -18,7 +18,8 @@ module Kernel
   def caller_locations: (?Integer start_or_range, ?Integer length) -> ::Array[Thread::Backtrace::Location]?
                       | (?::Range[Integer] start_or_range) -> ::Array[Thread::Backtrace::Location]?
 
-  def catch: (?Object tag) { (Object arg0) -> untyped } -> untyped
+  def catch: [T] (T tag) { (T tag) -> untyped } -> untyped
+           | () { (Object tag) -> untyped } -> untyped
 
   # In a perfect world this should be:
   # 
@@ -53,6 +54,7 @@ module Kernel
   # try do "hello" end   #=> "hello"
   # ```
   def iterator?: () -> bool
+  alias block_given? iterator?
 
   # Returns the names of the current local variables.
   # 
@@ -75,18 +77,19 @@ module Kernel
 
   def =~: (untyped other) -> NilClass
 
-  def clone: () -> self
+  def clone: (?freeze: (TrueClass | FalseClass)) -> self
 
-  def display: (IO port) -> NilClass
+  def display: (?IO port) -> NilClass
 
   def dup: () -> self
 
   def enum_for: (?Symbol method, *untyped args) -> ::Enumerator[untyped, untyped]
               | (?Symbol method, *untyped args) { () -> untyped } -> ::Enumerator[untyped, untyped]
+  alias to_enum enum_for
 
   def eql?: (untyped other) -> bool
 
-  def `extend`: (Module mod) -> NilClass
+  def `extend`: (*Module mod) -> self
 
   # Creates a subprocess. If a block is specified, that block is run in the
   # subprocess, and the subprocess terminates with a status of zero.
@@ -124,61 +127,53 @@ module Kernel
 
   def instance_variable_get: (Symbol | String arg0) -> untyped
 
-  def instance_variable_set: (Symbol | String arg0, untyped arg1) -> untyped
+  def instance_variable_set: [T] (Symbol | String arg0, T arg1) -> T
 
   def instance_variables: () -> ::Array[Symbol]
 
   def is_a?: (Class | Module arg0) -> bool
+  alias kind_of? is_a?
 
-  def kind_of?: (Class arg0) -> bool
-
-  def method: (Symbol arg0) -> Method
+  def method: (Symbol | String arg0) -> Method
 
   def methods: (?bool regular) -> ::Array[Symbol]
 
-  def `nil?`: () -> bool
+  def `nil?`: () -> FalseClass
 
   def private_methods: (?bool all) -> ::Array[Symbol]
 
   def protected_methods: (?bool all) -> ::Array[Symbol]
 
-  def public_method: (Symbol arg0) -> Method
+  def public_method: (Symbol | String arg0) -> Method
 
   def public_methods: (?bool all) -> ::Array[Symbol]
 
   def `public_send`: (Symbol | String arg0, *untyped args) -> untyped
+                   | (Symbol | String arg0, *untyped args) { (*untyped) -> untyped } -> untyped
 
-  def remove_instance_variable: (Symbol arg0) -> untyped
+  def remove_instance_variable: (Symbol | String arg0) -> untyped
 
   def `send`: (String | Symbol arg0, *untyped arg1) -> untyped
-            | (String | Symbol arg0, *untyped arg1) { () -> untyped } -> untyped
+            | (String | Symbol arg0, *untyped arg1) { (*untyped) -> untyped } -> untyped
 
   def `singleton_class`: () -> Class
 
-  def singleton_method: (Symbol arg0) -> Method
+  def singleton_method: (Symbol | String arg0) -> Method
 
   def singleton_methods: (?bool all) -> ::Array[Symbol]
 
   def taint: () -> self
+  alias untrust taint
 
   def tainted?: () -> bool
+  alias untrusted? tainted?
 
   def tap: () { (untyped x) -> void } -> self
 
-  def to_enum: (?Symbol method, *untyped args) -> ::Enumerator[untyped, untyped]
-             | (?Symbol method, *untyped args) { () -> untyped } -> ::Enumerator[untyped, untyped]
-
   def to_s: () -> String
 
-  def trust: () -> self
-
-  def `undef`: (*untyped arg) -> void
-
   def untaint: () -> self
-
-  def untrust: () -> self
-
-  def untrusted?: () -> bool
+  alias trust untaint
 
   # Returns `arg` as an [Array](https://ruby-doc.org/core-2.6.3/Array.html)
   # .
@@ -199,10 +194,11 @@ module Kernel
   # Array(nil)         #=> []
   # Array(1)           #=> [1]
   # ```
-  def Array: (NilClass x) -> untyped
-           | (untyped x) -> ::Array[untyped]
-
-  def BigDecimal: (Integer | Float | Rational | BigDecimal | String initial, ?Integer digits, ?exception: bool exception) -> BigDecimal
+  def Array: (NilClass x) -> [ ]
+           | [T] (::Array[T] x) -> ::Array[T]
+           | [T] (::Range[T] x) -> ::Array[T]
+           | [K, V] (::Hash[K, V] x) -> ::Array[[K, V]]
+           | [T] (T x) -> ::Array[T]
 
   def Complex: (Numeric | String x, ?Numeric | String y, ?exception: bool exception) -> Complex
 
@@ -210,7 +206,8 @@ module Kernel
 
   def Hash: [K, V] (Object x) -> ::Hash[K, V]
 
-  def Integer: (Numeric | String arg, ?Integer base, ?exception: bool exception) -> Integer
+  def Integer: (Numeric | String arg, ?exception: bool exception) -> Integer
+             | (String arg, ?Integer base, ?exception: bool exception) -> Integer
 
   def Rational: (Numeric | String | Object x, ?Numeric | String y, ?exception: bool exception) -> Rational
 
@@ -255,23 +252,6 @@ module Kernel
   # eval("param", b)   #=> "hello"
   # ```
   def binding: () -> Binding
-
-  # Returns `true` if `yield` would execute a block in the current context.
-  # The `iterator?` form is mildly deprecated.
-  # 
-  # ```ruby
-  # def try
-  #   if block_given?
-  #     yield
-  #   else
-  #     "no block"
-  #   end
-  # end
-  # try                  #=> "no block"
-  # try { "hello" }      #=> "hello"
-  # try do "hello" end   #=> "hello"
-  # ```
-  def block_given?: () -> bool
 
   # Initiates the termination of the Ruby script by raising the `SystemExit`
   # exception. This exception may be caught. The optional parameter is used
@@ -333,13 +313,14 @@ module Kernel
   # `Exception` object or `nil`, can be specified via the `:cause`
   # argument.
   def fail: () -> bot
-          | (?String arg0) -> bot
-          | (?Class arg0, ?::Array[String] arg1) -> bot
-          | (?Class arg0, ?String arg1, ?::Array[String] arg2) -> bot
+          | (String arg0) -> bot
+          | (?Exception arg0, ?String arg1, ?::Array[String] arg2) -> bot
+  alias raise fail
 
   def format: (String format, *untyped args) -> String
+  alias sprintf format
 
-  def gets: (?String arg0, ?Integer arg1) -> String
+  def gets: (?String arg0, ?Integer arg1) -> String?
 
   # Returns an array of the names of global variables.
   # 
@@ -381,7 +362,8 @@ module Kernel
   def loop: () { () -> untyped } -> bot
           | () -> ::Enumerator[untyped, bot]
 
-  def open: (String name, ?String | Integer rest, ?String block) -> IO?
+  def open: (String name, ?String mode, ?Integer perm) -> IO?
+          | [T] (String name, ?String mode, ?Integer perm) { (IO) -> T } -> T
 
   # Prints each object in turn to `$stdout` . If the output field separator
   # ( `$,` ) is not `nil`, its contents will appear between each field. If
@@ -400,15 +382,16 @@ module Kernel
   # 
   #     cat12399
   #     cat, 1, 2, 3, 99
-  def print: (*Kernel args) -> NilClass
+  def print: (*Kernel args) -> nil
 
-  def printf: (?IO arg0, ?String arg1, *untyped arg2) -> NilClass
+  def printf: (?IO arg0, ?String arg1, *untyped arg2) -> nil
 
   def proc: () { () -> untyped } -> Proc
 
   def lambda: () { () -> untyped } -> Proc
 
   def putc: (Integer arg0) -> Integer
+          | (String arg0) -> String
 
   def puts: (*untyped arg0) -> NilClass
 
@@ -468,38 +451,13 @@ module Kernel
   def sleep: () -> bot
            | (Numeric duration) -> Integer
 
-  def sprintf: (String format, *untyped args) -> String
-
   def syscall: (Integer num, *untyped args) -> untyped
 
-  def test: (String cmd, String file1, ?String file2) -> (TrueClass | FalseClass | Time)
+  def test: (String | Integer cmd, String | IO file1, ?String | IO file2) -> (TrueClass | FalseClass | Time | nil | Integer)
 
   def throw: (Object tag, ?untyped obj) -> bot
 
-  def warn: (*String msg) -> NilClass
-
-  # With no arguments, raises the exception in `$!` or raises a
-  # `RuntimeError` if `$!` is `nil` . With a single `String` argument,
-  # raises a `RuntimeError` with the string as a message. Otherwise, the
-  # first parameter should be the name of an `Exception` class (or an object
-  # that returns an `Exception` object when sent an `exception` message).
-  # The optional second parameter sets the message associated with the
-  # exception, and the third parameter is an array of callback information.
-  # Exceptions are caught by the `rescue` clause of `begin...end` blocks.
-  # 
-  # ```ruby
-  # raise "Failed to create socket"
-  # raise ArgumentError, "No parameters", caller
-  # ```
-  # 
-  # The `cause` of the generated exception is automatically set to the
-  # “current” exception ( `$!` ) if any. An alternative value, either an
-  # `Exception` object or `nil`, can be specified via the `:cause`
-  # argument.
-  def raise: () -> bot
-           | (?String arg0) -> bot
-           | (?Class arg0, ?String arg1, ?::Array[String] arg2) -> bot
-           | (?Exception arg0, ?String arg1, ?::Array[String] arg2) -> bot
+  def warn: (*untyped msg, ?uplevel: Integer | nil) -> NilClass
 
   # Replaces the current process by running the given external *command* ,
   # which can take one of the following forms:

--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -1,6 +1,484 @@
+require 'securerandom'
+
 class KernelTest < StdlibTest
   target Kernel
   using hook.refinement
+
+  def test_caller
+    caller(1, 2)
+    caller(1)
+    caller(1..2)
+    caller
+  end
+
+  def test_caller_locations
+    caller_locations(1, 2)
+    caller_locations(1)
+    caller_locations(1..2)
+    caller_locations
+  end
+
+  def test_catch_throw
+    catch do |tag|
+      throw tag
+    end
+
+    catch("tag") do |tag|
+      throw tag
+    end
+  end
+
+  def test_class
+    Object.new.class
+  end
+
+  def test_define_singleton_method
+    define_singleton_method("_#{SecureRandom.hex(10)}") {}
+    define_singleton_method(:"_#{SecureRandom.hex(10)}") {}
+    define_singleton_method("_#{SecureRandom.hex(10)}", proc {})
+    define_singleton_method(:"_#{SecureRandom.hex(10)}", proc {})
+  end
+
+  def test_eval
+    eval "p"
+    eval "p", binding, "fname", 1
+  end
+
+  def test_iterator?
+    iterator?
+    block_given?
+  end
+
+  def test_local_variables
+    _ = x = 1
+    local_variables
+  end
+
+  def test_srand
+    srand
+    srand(10)
+    srand(10.5)
+  end
+
+  def test_not_tilde
+    Object.new !~ Object.new
+  end
+
+  def test_spaceship
+    Object.new <=> Object.new
+  end
+
+  def test_eqeqeq
+    Object.new === Object.new
+  end
+
+  def test_eq_tilde
+    Object.new =~ Object.new
+  end
+
+  def test_clone
+    Object.new.clone
+    Object.new.clone(freeze: false)
+  end
+
+  def test_display
+    1.display
+    1.display(STDERR)
+  end
+
+  def test_dup
+    1.dup
+  end
+
+  def test_enum_for
+    enum_for
+    to_enum
+
+    enum_for :then
+    enum_for :then, 1
+
+    enum_for(:then, 1) { 2 }
+  end
+
+  def test_eql?
+    Object.new.eql? 1
+  end
+
+  def test_extend
+    Object.new.extend Module.new
+    Object.new.extend Module.new, Module.new
+  end
+
+  def test_fork
+    if Process.respond_to?(:fork)
+      exit unless fork
+      fork { exit }
+    end
+  end
+
+  def test_freeze
+    Object.new.freeze
+  end
+
+  def test_frozen?
+    Object.new.frozen?
+  end
+
+  def test_hash
+    Object.new.hash
+  end
+
+  def test_initialize_copy
+    Object.new.instance_eval do
+      initialize_copy(Object.new)
+    end
+  end
+
+  def test_inspect
+    Object.new.inspect
+  end
+
+  def test_instance_of?
+    Object.new.instance_of? String
+  end
+
+  def test_instance_variable_defined?
+    Object.new.instance_variable_defined?('@foo')
+    Object.new.instance_variable_defined?(:@bar)
+  end
+
+  def test_instance_variable_get
+    Object.new.instance_variable_get('@foo')
+    Object.new.instance_variable_get(:@bar)
+  end
+
+  def test_instance_variable_set
+    Object.new.instance_variable_set('@foo', 1)
+    Object.new.instance_variable_set(:@bar, 2)
+  end
+
+  def test_instance_variables
+    obj = Object.new
+    obj.instance_eval do
+      @foo = 1
+    end
+    obj.instance_variables
+  end
+
+  def test_is_a?
+    Object.new.is_a? String
+    Object.new.kind_of? Enumerable
+  end
+
+  def test_method
+    Object.new.method(:tap)
+    Object.new.method('yield_self')
+  end
+
+  def test_methods
+    Object.new.methods
+    Object.new.methods true
+    Object.new.methods false
+  end
+
+  def test_nil?
+    Object.new.nil?
+  end
+
+  def test_private_methods
+    Object.new.private_methods
+    Object.new.private_methods true
+    Object.new.private_methods false
+  end
+
+  def test_protected_methods
+    Object.new.protected_methods
+    Object.new.protected_methods true
+    Object.new.protected_methods false
+  end
+
+  def test_public_method
+    Object.new.public_method(:tap)
+    Object.new.public_method('yield_self')
+  end
+
+  def test_public_methods
+    Object.new.public_methods
+    Object.new.public_methods true
+    Object.new.public_methods false
+  end
+
+  def test_public_send
+    Object.new.public_send(:inspect)
+    Object.new.public_send('inspect')
+    Object.new.public_send(:public_send, :inspect)
+    Object.new.public_send(:tap) { 1 }
+    Object.new.public_send(:tap) { |this| this }
+  end
+
+  def test_remove_instance_variable
+    obj = Object.new
+    obj.instance_eval do
+      @foo = 1
+      @bar = 2
+    end
+
+    obj.remove_instance_variable(:@foo)
+    obj.remove_instance_variable('@bar')
+  end
+
+  def test_send
+    Object.new.send(:inspect)
+    Object.new.send('inspect')
+    Object.new.send(:public_send, :inspect)
+    Object.new.send(:tap) { 1 }
+    Object.new.send(:tap) { |this| this }
+  end
+
+  def test_singleton_class
+    Object.new.singleton_class
+  end
+
+  def test_singleton_method
+    o = Object.new
+    def o.x
+    end
+    o.singleton_method :x
+    o.singleton_method 'x'
+  end
+
+  def test_singleton_methods
+    o = Object.new
+    def o.x
+    end
+    o.singleton_methods
+  end
+
+  def test_taint
+    Object.new.taint
+    Object.new.untrust
+  end
+
+  def test_tainted?
+    Object.new.tainted?
+    Object.new.untrusted?
+  end
+
+  def test_tap
+    Object.new.tap do |this|
+      this
+    end
+  end
+
+  def test_to_s
+    Object.new.to_s
+  end
+
+  def test_untaint
+    Object.new.untaint
+    Object.new.trust
+  end
+
+  def test_Array
+    Array(nil)
+    Array('foo')
+    Array(['foo'])
+    Array(1..4)
+    Array({foo: 1})
+  end
+
+  def test_Complex
+    Complex(1.3)
+    Complex(42)
+    Complex(1, 2)
+    Complex('42', exception: true)
+  end
+
+  def test_Float
+    Float(42)
+    Float(1.4)
+    Float('1.4')
+    Float('1.4', exception: true)
+  end
+
+  def test_hash
+    Hash(nil)
+    Hash([])
+    Hash({key: 1})
+  end
+
+  def test_Integer
+    Integer(42)
+    Integer(2.3)
+    Integer('2', exception: true)
+    Integer('11', 2, exception: true)
+  end
+
+  def test_Rational
+    Rational(42)
+    Rational(42.0, 3)
+    Rational('42.0', 3, exception: true)
+  end
+
+  def test_String
+    String('foo')
+    String([])
+    String(nil)
+  end
+
+  def test___callee__
+    __callee__
+  end
+
+  def test___dir__
+    __dir__
+  end
+
+  def test___method__
+    __method__
+  end
+
+  def test_backtick
+    `echo 1`
+  end
+
+  def test_abort
+    begin
+      abort
+    rescue SystemExit
+    end
+
+    begin
+      abort 'foo'
+    rescue SystemExit
+    end
+  end
+
+  def test_at_exit
+    at_exit { 'foo' }
+  end
+
+  def test_autoload
+    autoload 'FooBar', 'fname'
+    autoload :FooBar, 'fname'
+  end
+
+  def test_autoload
+    autoload? 'FooBar'
+    autoload? :FooBarBaz
+  end
+
+  def test_binding
+    binding
+  end
+
+  def test_exit
+    begin
+      exit
+    rescue SystemExit
+    end
+
+    begin
+      exit 1
+    rescue SystemExit
+    end
+
+    begin
+      exit true
+    rescue SystemExit
+    end
+
+    begin
+      exit false
+    rescue SystemExit
+    end
+  end
+
+  def test_exit!
+    # TODO
+  end
+
+  def test_fail
+    # TODO
+  end
+
+  def test_format
+    format 'x'
+    format '%d', 1
+    sprintf '%d%s', 1, 2
+  end
+
+  def test_gets
+    # TODO
+  end
+
+  def test_global_variables
+    global_variables
+  end
+
+  def test_load
+    # TODO
+  end
+
+  def test_loop
+    loop { break }
+    loop
+  end
+
+  def test_open
+    open(__FILE__).close
+    open(__FILE__, 'r').close
+    open(__FILE__, 'r', 0644).close
+    open(__FILE__) do |f|
+      f.read
+    end
+  end
+
+  def test_print
+    $stdout = StringIO.new
+    print 1
+    print 'a', 2
+  ensure
+    $stdout = STDOUT
+  end
+
+  def test_printf
+    $stdout = StringIO.new
+    File.open('/dev/null', 'w') do |io|
+      printf io, 'a'
+      printf io, '%d', 2
+    end
+    # TODO
+    #   printf 's'
+    #   printf '%d', 2
+    #   printf '%d%s', 2, 1
+  ensure
+    $stdout = STDOUT
+  end
+
+  def test_proc
+    proc {}
+  end
+
+  def test_lambda
+    lambda {}
+  end
+
+  def test_putc
+    $stdout = StringIO.new
+    putc 1
+    putc 'a'
+  ensure
+    $stdout = STDOUT
+  end
+
+  def test_puts
+    $stdout = StringIO.new
+    puts 1
+    puts Object.new
+  ensure
+    $stdout = STDOUT
+  end
 
   def test_p
     $stdout = StringIO.new
@@ -8,5 +486,72 @@ class KernelTest < StdlibTest
     p 'a', 2
   ensure
     $stdout = STDOUT
+  end
+
+  def test_rand
+    rand
+    rand(10)
+    rand(1..10)
+    rand(1.0..10.0)
+  end
+
+  def test_readline
+    # TODO
+  end
+
+  def test_readlines
+    # TODO
+  end
+
+  def test_require
+    # TODO
+  end
+
+  def test_require_relative
+    # TODO
+  end
+
+  def test_select
+    # TODO
+  end
+
+  def test_sleep
+    # TODO
+    #   sleep
+
+    sleep 0.01
+  end
+
+  def test_syscall
+    # TODO
+  end
+
+  def test_test
+    test ?r, __FILE__
+    test ?r.ord, __FILE__
+    test ?s, __FILE__
+
+    File.open(__FILE__) do |f|
+      test ?r, f
+      test ?=, f, f
+    end
+  end
+
+  def test_warn
+    $stderr = StringIO.new
+    warn
+    warn 'foo'
+    warn 'foo', 'bar'
+    warn 'foo', uplevel: 1
+  ensure
+    $stderr = STDERR
+  end
+
+  def test_exec
+    # TODO
+  end
+
+  def test_system
+    # TODO
   end
 end


### PR DESCRIPTION
This pull request adds tests for all methods for `Kernel` module. And it updates some types because they are wrong.

I gave up writing tests for some methods, because they are difficult.
But `test_*` methods are available for all methods. I put "TODO" comment to the methods I gave up.