### PR TITLE
Add a generator of stdlib test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,4 +24,30 @@ task :test => :parser
 task :stdlib_test => :parser
 task :build => :parser
 
+namespace :generate do
+  task :stdlib_test, [:class] do |_task, args|
+    klass = args.fetch(:class) do
+      raise "Class name is necessary. e.g. rake 'generate:stdlib_test[String]'"
+    end
+
+    path = Pathname("test/stdlib/#{klass}_test.rb")
+    raise "#{path} already exists!" if path.exist?
+
+    path.write <<~RUBY
+      class #{klass}Test < StdlibTest
+        target #{klass}
+        using hook.refinement
+
+        # def test_method_name
+        #   # Call the method
+        #   method_name(arg)
+        #   method_name(arg, arg2)
+        # end
+      end
+    RUBY
+
+    puts "Created: #{path}"
+  end
+end
+
 CLEAN.include("lib/ruby/signature/parser.rb")

--- a/doc/stdlib.md
+++ b/doc/stdlib.md
@@ -14,7 +14,14 @@ We support writing tests for stdlib signatures.
 
 ### Writing tests
 
-Put the test scripts in `test/stdlib` directory with `[class_name]_test.rb`, like `String_test.rb` and `File_test.rb`.
+First, execute `generate:stdlib_test` rake task with a class name that you want to test.
+
+```bash
+$ bundle exec rake 'generate:stdlib_test[String]'
+Created: test/stdlib/String_test.rb
+```
+
+It generates `test/stdlib/[class_name]_test.rb`.
 The test scripts would look like the following:
 
 ```rb
@@ -39,7 +46,7 @@ You need two method calls, `target` and `using`.
 `using hook.refinement` installs a special instrumentation for stdlib, based on refinements.
 And you write the sample programs which calls all of the patterns of overloads.
 
-Note that the instrumentation is based on refinmenets and you need to write all method calls in the unit class definitions.
+Note that the instrumentation is based on refinements and you need to write all method calls in the unit class definitions.
 If the execution of the program escape from the class definition, the instrumentation is disabled and no check will be done.
 
 ### Running tests


### PR DESCRIPTION
This pull request adds a generator for stdlib test.


```bash
$ bundle exec rake 'generate:stdlib_test[Foo]'
Created: test/stdlib/Foo_test.rb

$ cat test/stdlib/Foo_test.rb
class FooTest < StdlibTest
  target Foo
  using hook.refinement

  # def test_method_name
  #   # Call the method
  #   method_name(arg)
  #   method_name(arg, arg2)
  # end
end
```



Now we do not have many tests for stdlib. So we need to write many test cases.
I think this generator is helpful for writing test.


