### PR TITLE
Import RDoc annotations

### DIFF
--- a/bin/annotate-with-rdoc
+++ b/bin/annotate-with-rdoc
@@ -1,0 +1,136 @@
+#!/usr/bin/env ruby
+
+require "ruby/signature"
+require "rdoc"
+
+def store_for_class(name, stores:)
+  stores.find do |store|
+    store.find_class_named(name) || store.find_module_named(name)
+  end
+end
+
+def format_comment(comment)
+  out = RDoc::Markup::Document.new
+  out << comment
+  formatter = RDoc::Markup::ToMarkdown.new
+  out.accept(formatter)
+end
+
+def comment_for_constant(decl, stores:)
+  class_name = decl.name.namespace.to_type_name.to_s
+  klass = store_for_class(class_name, stores: stores)&.yield_self {|store|
+    store.find_class_named(class_name) || store.find_module_named(class_name)
+  }
+
+  constant = klass.constants.find do |const|
+    const.name == decl.name.name.to_s
+  end
+
+  if constant&.documented?
+    string = format_comment(constant.comment)
+    Ruby::Signature::AST::Comment.new(location: nil, string: string)
+  end
+end
+
+def comment_for_class(decl, stores:)
+  name = decl.name.to_s
+  klass = store_for_class(name, stores: stores)&.yield_self {|store|
+    store.find_class_named(name) || store.find_module_named(name)
+  }
+
+  if klass&.documented?
+    string = format_comment(klass.comment)
+    Ruby::Signature::AST::Comment.new(location: nil, string: string)
+  end
+end
+
+def comment_for_method(klass, method, stores:)
+  method = store_for_class(klass, stores: stores)&.load_method(klass, method)
+
+  if method&.documented?
+    string = format_comment(method.comment)
+    Ruby::Signature::AST::Comment.new(location: nil, string: string)
+  end
+
+rescue RDoc::Store::MissingFileError
+  puts "  👺 No document found for #{klass}#{method}"
+  nil
+end
+
+if ARGV.empty?
+  puts 'annotate-with-rdoc [RBS files...]'
+  exit
+end
+
+stores = []
+RDoc::RI::Paths.each true, true, false, false do |path, type|
+  puts "Loading store from #{path}..."
+  store = RDoc::RI::Store.new(path, type)
+  store.load_all
+  stores << store
+end
+
+ARGV.map {|f| Pathname(f) }.each do |path|
+  puts "Opening #{path}..."
+
+  buffer = Ruby::Signature::Buffer.new(name: path, content: path.read)
+  sigs = Ruby::Signature::Parser.parse_signature(buffer)
+
+  sigs.each do |decl|
+    case decl
+    when Ruby::Signature::AST::Declarations::Constant
+      puts "  Importing documentation for #{decl.name}..."
+      comment = comment_for_constant(decl, stores: stores)
+      decl.instance_variable_set(:@comment, comment)
+    when Ruby::Signature::AST::Declarations::Class, Ruby::Signature::AST::Declarations::Module
+      puts "  Importing documentation for #{decl.name}..."
+      comment = comment_for_class(decl, stores: stores)
+      decl.instance_variable_set(:@comment, comment)
+
+      decl.members.each do |member|
+        case member
+        when Ruby::Signature::AST::Members::MethodDefinition
+          puts "    Processing #{member.name}..."
+
+          method_name = case
+                        when member.instance?
+                          "##{member.name}"
+                        when member.singleton?
+                          "::#{member.name}"
+                        end
+
+          comment = comment_for_method(decl.name.to_s, method_name, stores: stores)
+
+          unless comment
+            if member.instance? && member.name == :initialize
+              comment = comment_for_method(decl.name.to_s, '::new', stores: stores)
+            end
+          end
+
+          member.instance_variable_set(:@comment, comment)
+        when Ruby::Signature::AST::Members::AttrReader, Ruby::Signature::AST::Members::AttrAccessor, Ruby::Signature::AST::Members::AttrWriter
+          puts "    👻 Attributes not supported (#{decl.name})"
+        when Ruby::Signature::AST::Members::Alias
+          puts "    Processing #{member.new_name}(alias)..."
+          prefix = case
+                   when member.instance?
+                     "#"
+                   when member.singleton?
+                     "."
+                   end
+          name = "#{prefix}#{member.new_name}"
+
+          comment = comment_for_method(decl.name.to_s, name, stores: stores)
+          member.instance_variable_set(:@comment, comment)
+        end
+      end
+    end
+  end
+
+  puts "Writing #{path}..."
+  path.open('w') do |out|
+    writer = Ruby::Signature::Writer.new(out: out)
+    writer.write sigs
+  end
+end
+

--- a/bin/query-rdoc
+++ b/bin/query-rdoc
@@ -1,0 +1,91 @@
+#!/usr/bin/env ruby
+
+require "rdoc"
+
+def store_for_class(name, stores:)
+  stores.find do |store|
+    store.find_class_named(name) || store.find_module_named(name)
+  end
+end
+
+def format_comment(comment)
+  out = RDoc::Markup::Document.new
+  out << comment
+  formatter = RDoc::Markup::ToMarkdown.new
+  out.accept(formatter)
+end
+
+def comment_for_constant(name, stores:)
+  *class_components, const_name = name.split(/::/)
+  class_name = class_components.join("::")
+
+  klass = store_for_class(class_name, stores: stores)&.yield_self {|store|
+    store.find_class_named(class_name) || store.find_module_named(class_name)
+  }
+
+  constant = klass.constants.find do |const|
+    const.name == const_name
+  end
+
+  if constant&.documented?
+    format_comment(constant.comment)
+  end
+end
+
+def comment_for_class(class_name, stores:)
+  klass = store_for_class(class_name, stores: stores)&.yield_self {|store|
+    store.find_class_named(class_name) || store.find_module_named(class_name)
+  }
+
+  if klass&.documented?
+    format_comment(klass.comment)
+  end
+end
+
+def comment_for_method(klass, method, stores:)
+  method = store_for_class(klass, stores: stores)&.load_method(klass, method)
+
+  if method&.documented?
+    format_comment(method.comment)
+  end
+rescue RDoc::Store::MissingFileError
+  nil
+end
+
+if ARGV.empty?
+  puts 'query-rdoc [subject]'
+  puts "  subject ::= ClassName         (class, module, or constant)"
+  puts "            | ClassName.method  (singleton method)"
+  puts "            | ClassName#method  (instance method)"
+  exit
+end
+
+stores = []
+RDoc::RI::Paths.each true, true, false, false do |path, type|
+  STDERR.puts "Loading store from #{path}..."
+  store = RDoc::RI::Store.new(path, type)
+  store.load_all
+  stores << store
+end
+
+subject = ARGV[0]
+
+case
+when match = subject.match(/(?<constant_name>[^#]+)#(?<method_name>.+)/)
+  STDERR.puts "Finding instance method #{match[:constant_name]} # #{match[:method_name]} ..."
+  comment = comment_for_method(match[:constant_name], "##{match[:method_name]}", stores: stores)
+when match = subject.match(/(?<constant_name>[^.]+)\.(?<method_name>.+)/)
+  STDERR.puts "Finding singleton method #{match[:constant_name]} . #{match[:method_name]} ..."
+  comment = comment_for_method(match[:constant_name], ".#{match[:method_name]}", stores: stores)
+else
+  STDERR.puts "Finding class/module/constant #{subject} ..."
+  comment = comment_for_class(subject, stores: stores) || comment_for_constant(subject, stores: stores)
+end
+
+if comment
+  STDERR.puts "Printing document..."
+  puts comment
+else
+  STDERR.puts "Nothing to print; failed to query the document..."
+  exit 1
+end

--- a/stdlib/builtin/basic_object.rbs
+++ b/stdlib/builtin/basic_object.rbs
@@ -1,100 +1,280 @@
-# [BasicObject](BasicObject) is the parent class of
-# all classes in Ruby. It's an explicit blank class.
+# BasicObject is the parent class of all classes in Ruby.  It's an explicit
+# blank class.
 # 
-# [BasicObject](BasicObject) can be used for creating
-# object hierarchies independent of Ruby's object hierarchy, proxy objects
-# like the Delegator class, or other uses where namespace pollution from
-# Ruby's methods and classes must be avoided.
+# BasicObject can be used for creating object hierarchies independent of Ruby's
+# object hierarchy, proxy objects like the Delegator class, or other uses where
+# namespace pollution from Ruby's methods and classes must be avoided.
 # 
-# To avoid polluting [BasicObject](BasicObject) for
-# other users an appropriately named subclass of
-# [BasicObject](BasicObject) should be created instead
-# of directly modifying BasicObject:
+# To avoid polluting BasicObject for other users an appropriately named subclass
+# of BasicObject should be created instead of directly modifying BasicObject:
 # 
-# ```ruby
-# class MyObjectSystem < BasicObject
-# end
-# ```
+#     class MyObjectSystem < BasicObject
+#     end
 # 
-# [BasicObject](BasicObject) does not include
-# [Kernel](https://ruby-doc.org/core-2.6.3/Kernel.html) (for methods like
-# `puts` ) and [BasicObject](BasicObject) is outside
-# of the namespace of the standard library so common classes will not be
-# found without using a full class path.
+# BasicObject does not include Kernel (for methods like `puts`) and BasicObject
+# is outside of the namespace of the standard library so common classes will not
+# be found without using a full class path.
 # 
-# A variety of strategies can be used to provide useful portions of the
-# standard library to subclasses of
-# [BasicObject](BasicObject). A subclass could
-# `include Kernel` to obtain `puts`, `exit`, etc. A custom Kernel-like
-# module could be created and included or delegation can be used via
-# [method\_missing](BasicObject#method-i-method_missing)
-# :
+# A variety of strategies can be used to provide useful portions of the standard
+# library to subclasses of BasicObject.  A subclass could `include Kernel` to
+# obtain `puts`, `exit`, etc.  A custom Kernel-like module could be created and
+# included or delegation can be used via #method_missing:
 # 
-# ```ruby
-# class MyObjectSystem < BasicObject
-#   DELEGATE = [:puts, :p]
+#     class MyObjectSystem < BasicObject
+#       DELEGATE = [:puts, :p]
 # 
-#   def method_missing(name, *args, &block)
-#     super unless DELEGATE.include? name
-#     ::Kernel.send(name, *args, &block)
-#   end
+#       def method_missing(name, *args, &block)
+#         super unless DELEGATE.include? name
+#         ::Kernel.send(name, *args, &block)
+#       end
 # 
-#   def respond_to_missing?(name, include_private = false)
-#     DELEGATE.include?(name) or super
-#   end
-# end
-# ```
+#       def respond_to_missing?(name, include_private = false)
+#         DELEGATE.include?(name) or super
+#       end
+#     end
 # 
-# Access to classes and modules from the Ruby standard library can be
-# obtained in a [BasicObject](BasicObject) subclass by
-# referencing the desired constant from the root like `::File` or
-# `::Enumerator` . Like
-# [method\_missing](BasicObject#method-i-method_missing)
-# , const\_missing can be used to delegate constant lookup to `Object` :
+# Access to classes and modules from the Ruby standard library can be obtained
+# in a BasicObject subclass by referencing the desired constant from the root
+# like `::File` or `::Enumerator`. Like #method_missing, #const_missing can be
+# used to delegate constant lookup to `Object`:
 # 
-# ```ruby
-# class MyObjectSystem < BasicObject
-#   def self.const_missing(name)
-#     ::Object.const_get(name)
-#   end
-# end
-# ```
+#     class MyObjectSystem < BasicObject
+#       def self.const_missing(name)
+#         ::Object.const_get(name)
+#       end
+#     end
+# 
 class BasicObject
   # Boolean negate.
+  # 
   def !: () -> bool
 
+  # Returns true if two objects are not-equal, otherwise false.
+  # 
   def !=: (untyped other) -> bool
 
+  # Equality --- At the `Object` level, `==` returns `true` only if `obj` and
+  # `other` are the same object. Typically, this method is overridden in
+  # descendant classes to provide class-specific meaning.
+  # 
+  # Unlike `==`, the `equal?` method should never be overridden by subclasses as
+  # it is used to determine object identity (that is, `a.equal?(b)` if and only if
+  # `a` is the same object as `b`):
+  # 
+  #     obj = "a"
+  #     other = obj.dup
+  # 
+  #     obj == other      #=> true
+  #     obj.equal? other  #=> false
+  #     obj.equal? obj    #=> true
+  # 
+  # The `eql?` method returns `true` if `obj` and `other` refer to the same hash
+  # key.  This is used by Hash to test members for equality.  For objects of class
+  # `Object`, `eql?` is synonymous with `==`.  Subclasses normally continue this
+  # tradition by aliasing `eql?` to their overridden `==` method, but there are
+  # exceptions.  `Numeric` types, for example, perform type conversion across
+  # `==`, but not across `eql?`, so:
+  # 
+  #     1 == 1.0     #=> true
+  #     1.eql? 1.0   #=> false
+  # 
   def ==: (untyped other) -> bool
 
-  # Returns an integer identifier for `obj` .
+  # Returns an integer identifier for `obj`.
   # 
   # The same number will be returned on all calls to `object_id` for a given
   # object, and no two active objects will share an id.
   # 
-  # Note: that some objects of builtin classes are reused for optimization.
-  # This is the case for immediate values and frozen string literals.
+  # Note: that some objects of builtin classes are reused for optimization. This
+  # is the case for immediate values and frozen string literals.
   # 
-  # Immediate values are not passed by reference but are passed by value:
-  # `nil`, `true`, `false`, Fixnums, Symbols, and some Floats.
+  # Immediate values are not passed by reference but are passed by value: `nil`,
+  # `true`, `false`, Fixnums, Symbols, and some Floats.
   # 
-  # ```ruby
-  # Object.new.object_id  == Object.new.object_id  # => false
-  # (21 * 2).object_id    == (21 * 2).object_id    # => true
-  # "hello".object_id     == "hello".object_id     # => false
-  # "hi".freeze.object_id == "hi".freeze.object_id # => true
-  # ```
+  #     Object.new.object_id  == Object.new.object_id  # => false
+  #     (21 * 2).object_id    == (21 * 2).object_id    # => true
+  #     "hello".object_id     == "hello".object_id     # => false
+  #     "hi".freeze.object_id == "hi".freeze.object_id # => true
+  # 
   def __id__: () -> Integer
 
-  def __send__: (Symbol | String arg0, *untyped arg1) -> untyped
+  # Invokes the method identified by *symbol*, passing it any arguments specified.
+  # You can use `__send__` if the name `send` clashes with an existing method in
+  # *obj*. When the method is identified by a string, the string is converted to a
+  # symbol.
+  # 
+  #     class Klass
+  #       def hello(*args)
+  #         "Hello " + args.join(' ')
+  #       end
+  #     end
+  #     k = Klass.new
+  #     k.send :hello, "gentle", "readers"   #=> "Hello gentle readers"
+  # 
+  def __send__: (String | Symbol arg0, *untyped args) -> untyped
 
+  # Equality --- At the `Object` level, `==` returns `true` only if `obj` and
+  # `other` are the same object. Typically, this method is overridden in
+  # descendant classes to provide class-specific meaning.
+  # 
+  # Unlike `==`, the `equal?` method should never be overridden by subclasses as
+  # it is used to determine object identity (that is, `a.equal?(b)` if and only if
+  # `a` is the same object as `b`):
+  # 
+  #     obj = "a"
+  #     other = obj.dup
+  # 
+  #     obj == other      #=> true
+  #     obj.equal? other  #=> false
+  #     obj.equal? obj    #=> true
+  # 
+  # The `eql?` method returns `true` if `obj` and `other` refer to the same hash
+  # key.  This is used by Hash to test members for equality.  For objects of class
+  # `Object`, `eql?` is synonymous with `==`.  Subclasses normally continue this
+  # tradition by aliasing `eql?` to their overridden `==` method, but there are
+  # exceptions.  `Numeric` types, for example, perform type conversion across
+  # `==`, but not across `eql?`, so:
+  # 
+  #     1 == 1.0     #=> true
+  #     1.eql? 1.0   #=> false
+  # 
   def equal?: (untyped other) -> bool
 
-  def instance_eval: (String arg0, ?String filename, ?Integer lineno) -> untyped
+  # Evaluates a string containing Ruby source code, or the given block, within the
+  # context of the receiver (*obj*). In order to set the context, the variable
+  # `self` is set to *obj* while the code is executing, giving the code access to
+  # *obj*'s instance variables and private methods.
+  # 
+  # When `instance_eval` is given a block, *obj* is also passed in as the block's
+  # only argument.
+  # 
+  # When `instance_eval` is given a `String`, the optional second and third
+  # parameters supply a filename and starting line number that are used when
+  # reporting compilation errors.
+  # 
+  #     class KlassWithSecret
+  #       def initialize
+  #         @secret = 99
+  #       end
+  #       private
+  #       def the_secret
+  #         "Ssssh! The secret is #{@secret}."
+  #       end
+  #     end
+  #     k = KlassWithSecret.new
+  #     k.instance_eval { @secret }          #=> 99
+  #     k.instance_eval { the_secret }       #=> "Ssssh! The secret is 99."
+  #     k.instance_eval {|obj| obj == self } #=> true
+  # 
+  def instance_eval: (String, ?String filename, ?Integer lineno) -> untyped
                    | [U] () { (self) -> U } -> U
 
+  # Executes the given block within the context of the receiver (*obj*). In order
+  # to set the context, the variable `self` is set to *obj* while the code is
+  # executing, giving the code access to *obj*'s instance variables.  Arguments
+  # are passed as block parameters.
+  # 
+  #     class KlassWithSecret
+  #       def initialize
+  #         @secret = 99
+  #       end
+  #     end
+  #     k = KlassWithSecret.new
+  #     k.instance_exec(5) {|x| @secret+x }   #=> 104
+  # 
   def instance_exec: [U, V] (*V args) { (*V args) -> U } -> U
 
-  private
+  # Not documented
+  # 
   def initialize: () -> void
+
+  private
+
+  # Invoked by Ruby when *obj* is sent a message it cannot handle. *symbol* is the
+  # symbol for the method called, and *args* are any arguments that were passed to
+  # it. By default, the interpreter raises an error when this method is called.
+  # However, it is possible to override the method to provide more dynamic
+  # behavior. If it is decided that a particular method should not be handled,
+  # then *super* should be called, so that ancestors can pick up the missing
+  # method. The example below creates a class `Roman`, which responds to methods
+  # with names consisting of roman numerals, returning the corresponding integer
+  # values.
+  # 
+  #     class Roman
+  #       def roman_to_int(str)
+  #         # ...
+  #       end
+  #       def method_missing(methId)
+  #         str = methId.id2name
+  #         roman_to_int(str)
+  #       end
+  #     end
+  # 
+  #     r = Roman.new
+  #     r.iv      #=> 4
+  #     r.xxiii   #=> 23
+  #     r.mm      #=> 2000
+  # 
+  def method_missing: (Symbol, *untyped) -> untyped
+
+  # Invoked as a callback whenever a singleton method is added to the receiver.
+  # 
+  #     module Chatty
+  #       def Chatty.singleton_method_added(id)
+  #         puts "Adding #{id.id2name}"
+  #       end
+  #       def self.one()     end
+  #       def two()          end
+  #       def Chatty.three() end
+  #     end
+  # 
+  # *produces:*
+  # 
+  #     Adding singleton_method_added
+  #     Adding one
+  #     Adding three
+  # 
+  def singleton_method_added: (Symbol) -> void
+
+  # Invoked as a callback whenever a singleton method is removed from the
+  # receiver.
+  # 
+  #     module Chatty
+  #       def Chatty.singleton_method_removed(id)
+  #         puts "Removing #{id.id2name}"
+  #       end
+  #       def self.one()     end
+  #       def two()          end
+  #       def Chatty.three() end
+  #       class << self
+  #         remove_method :three
+  #         remove_method :one
+  #       end
+  #     end
+  # 
+  # *produces:*
+  # 
+  #     Removing three
+  #     Removing one
+  # 
+  def singleton_method_removed: (Symbol) -> void
+
+  # Invoked as a callback whenever a singleton method is undefined in the
+  # receiver.
+  # 
+  #     module Chatty
+  #       def Chatty.singleton_method_undefined(id)
+  #         puts "Undefining #{id.id2name}"
+  #       end
+  #       def Chatty.one()   end
+  #       class << self
+  #          undef_method(:one)
+  #       end
+  #     end
+  # 
+  # *produces:*
+  # 
+  #     Undefining one
+  # 
+  def singleton_method_undefined: (Symbol) -> void
 end

--- a/stdlib/builtin/object.rbs
+++ b/stdlib/builtin/object.rbs
@@ -1,127 +1,819 @@
-# [Object](Object) is the default root of all Ruby
-# objects. [Object](Object) inherits from
-# [BasicObject](https://ruby-doc.org/core-2.6.3/BasicObject.html) which
-# allows creating alternate object hierarchies. Methods on
-# [Object](Object) are available to all classes unless
-# explicitly overridden.
+# Object is the default root of all Ruby objects.  Object inherits from
+# BasicObject which allows creating alternate object hierarchies.  Methods on
+# Object are available to all classes unless explicitly overridden.
 # 
-# [Object](Object) mixes in the
-# [Kernel](https://ruby-doc.org/core-2.6.3/Kernel.html) module, making the
-# built-in kernel functions globally accessible. Although the instance
-# methods of [Object](Object) are defined by the
-# [Kernel](https://ruby-doc.org/core-2.6.3/Kernel.html) module, we have
-# chosen to document them here for clarity.
+# Object mixes in the Kernel module, making the built-in kernel functions
+# globally accessible.  Although the instance methods of Object are defined by
+# the Kernel module, we have chosen to document them here for clarity.
 # 
-# When referencing constants in classes inheriting from
-# [Object](Object) you do not need to use the full
-# namespace. For example, referencing `File` inside `YourClass` will find
-# the top-level [File](https://ruby-doc.org/core-2.6.3/File.html) class.
+# When referencing constants in classes inheriting from Object you do not need
+# to use the full namespace.  For example, referencing `File` inside `YourClass`
+# will find the top-level File class.
 # 
-# In the descriptions of Object's methods, the parameter *symbol* refers
-# to a symbol, which is either a quoted string or a
-# [Symbol](https://ruby-doc.org/core-2.6.3/Symbol.html) (such as `:name`
-# ).
+# In the descriptions of Object's methods, the parameter *symbol* refers to a
+# symbol, which is either a quoted string or a Symbol (such as `:name`).
+# 
 class Object < BasicObject
   include Kernel
 
+  # Returns true if two objects do not match (using the *=~* method), otherwise
+  # false.
+  # 
   def !~: (untyped) -> bool
 
+  # Returns 0 if `obj` and `other` are the same object or `obj == other`,
+  # otherwise nil.
+  # 
+  # The `<=>` is used by various methods to compare objects, for example
+  # Enumerable#sort, Enumerable#max etc.
+  # 
+  # Your implementation of `<=>` should return one of the following values: -1, 0,
+  # 1 or nil. -1 means self is smaller than other. 0 means self is equal to other.
+  # 1 means self is bigger than other. Nil means the two values could not be
+  # compared.
+  # 
+  # When you define `<=>`, you can include Comparable to gain the methods `<=`,
+  # `<`, `==`, `>=`, `>` and `between?`.
+  # 
   def <=>: (untyped) -> Integer?
 
+  # Case Equality -- For class Object, effectively the same as calling `#==`, but
+  # typically overridden by descendants to provide meaningful semantics in `case`
+  # statements.
+  # 
   def ===: (untyped) -> bool
 
+  # This method is deprecated.
+  # 
+  # This is not only unuseful but also troublesome because it may hide a type
+  # error.
+  # 
   def =~: (untyped) -> bool
 
-  def class: -> untyped
+  # Returns the class of *obj*. This method must always be called with an explicit
+  # receiver, as `class` is also a reserved word in Ruby.
+  # 
+  #     1.class      #=> Integer
+  #     self.class   #=> Object
+  # 
+  def `class`: () -> untyped
 
+  # Produces a shallow copy of *obj*---the instance variables of *obj* are copied,
+  # but not the objects they reference. `clone` copies the frozen (unless :freeze
+  # keyword argument is given with a false value) and tainted state of *obj*. See
+  # also the discussion under `Object#dup`.
+  # 
+  #     class Klass
+  #        attr_accessor :str
+  #     end
+  #     s1 = Klass.new      #=> #<Klass:0x401b3a38>
+  #     s1.str = "Hello"    #=> "Hello"
+  #     s2 = s1.clone       #=> #<Klass:0x401b3998 @str="Hello">
+  #     s2.str[1,4] = "i"   #=> "i"
+  #     s1.inspect          #=> "#<Klass:0x401b3a38 @str=\"Hi\">"
+  #     s2.inspect          #=> "#<Klass:0x401b3998 @str=\"Hi\">"
+  # 
+  # This method may have class-specific behavior.  If so, that behavior will be
+  # documented under the #`initialize_copy` method of the class.
+  # 
   def clone: (?freeze: bool) -> self
 
+  # Defines a singleton method in the receiver. The *method* parameter can be a
+  # `Proc`, a `Method` or an `UnboundMethod` object. If a block is specified, it
+  # is used as the method body.
+  # 
+  #     class A
+  #       class << self
+  #         def class_name
+  #           to_s
+  #         end
+  #       end
+  #     end
+  #     A.define_singleton_method(:who_am_i) do
+  #       "I am: #{class_name}"
+  #     end
+  #     A.who_am_i   # ==> "I am: A"
+  # 
+  #     guy = "Bob"
+  #     guy.define_singleton_method(:hello) { "#{self}: Hello there!" }
+  #     guy.hello    #=>  "Bob: Hello there!"
+  # 
   def define_singleton_method: (Symbol, Method | UnboundMethod) -> Symbol
                              | (Symbol) { (*untyped) -> untyped } -> Symbol
 
+  # Prints *obj* on the given port (default `$>`). Equivalent to:
+  # 
+  #     def display(port=$>)
+  #       port.write self
+  #       nil
+  #     end
+  # 
+  # For example:
+  # 
+  #     1.display
+  #     "cat".display
+  #     [ 4, 5, 6 ].display
+  #     puts
+  # 
+  # *produces:*
+  # 
+  #     1cat[4, 5, 6]
+  # 
   def display: (?_Writeable port) -> void
 
-  def dup: -> self
+  # Produces a shallow copy of *obj*---the instance variables of *obj* are copied,
+  # but not the objects they reference. `dup` copies the tainted state of *obj*.
+  # 
+  # This method may have class-specific behavior.  If so, that behavior will be
+  # documented under the #`initialize_copy` method of the class.
+  # 
+  # ### on dup vs clone
+  # 
+  # In general, `clone` and `dup` may have different semantics in descendant
+  # classes. While `clone` is used to duplicate an object, including its internal
+  # state, `dup` typically uses the class of the descendant object to create the
+  # new instance.
+  # 
+  # When using #dup, any modules that the object has been extended with will not
+  # be copied.
+  # 
+  #     class Klass
+  #       attr_accessor :str
+  #     end
+  # 
+  #     module Foo
+  #       def foo; 'foo'; end
+  #     end
+  # 
+  #     s1 = Klass.new #=> #<Klass:0x401b3a38>
+  #     s1.extend(Foo) #=> #<Klass:0x401b3a38>
+  #     s1.foo #=> "foo"
+  # 
+  #     s2 = s1.clone #=> #<Klass:0x401b3a38>
+  #     s2.foo #=> "foo"
+  # 
+  #     s3 = s1.dup #=> #<Klass:0x401b3a38>
+  #     s3.foo #=> NoMethodError: undefined method `foo' for #<Klass:0x401b3a38>
+  # 
+  def dup: () -> self
 
+  # Creates a new Enumerator which will enumerate by calling `method` on `obj`,
+  # passing `args` if any.
+  # 
+  # If a block is given, it will be used to calculate the size of the enumerator
+  # without the need to iterate it (see Enumerator#size).
+  # 
+  # ### Examples
+  # 
+  #     str = "xyz"
+  # 
+  #     enum = str.enum_for(:each_byte)
+  #     enum.each { |b| puts b }
+  #     # => 120
+  #     # => 121
+  #     # => 122
+  # 
+  #     # protect an array from being modified by some_method
+  #     a = [1, 2, 3]
+  #     some_method(a.to_enum)
+  # 
+  # It is typical to call to_enum when defining methods for a generic Enumerable,
+  # in case no block is passed.
+  # 
+  # Here is such an example, with parameter passing and a sizing block:
+  # 
+  #     module Enumerable
+  #       # a generic method to repeat the values of any enumerable
+  #       def repeat(n)
+  #         raise ArgumentError, "#{n} is negative!" if n < 0
+  #         unless block_given?
+  #           return to_enum(__method__, n) do # __method__ is :repeat here
+  #             sz = size     # Call size and multiply by n...
+  #             sz * n if sz  # but return nil if size itself is nil
+  #           end
+  #         end
+  #         each do |*val|
+  #           n.times { yield *val }
+  #         end
+  #       end
+  #     end
+  # 
+  #     %i[hello world].repeat(2) { |w| puts w }
+  #       # => Prints 'hello', 'hello', 'world', 'world'
+  #     enum = (1..14).repeat(3)
+  #       # => returns an Enumerator when called without a block
+  #     enum.first(4) # => [1, 1, 1, 2]
+  #     enum.size # => 42
+  # 
   def enum_for: (Symbol method, *untyped args) ?{ (*untyped args) -> Integer } -> Enumerator[untyped, untyped]
               | (*untyped args) ?{ (*untyped args) -> Integer } -> Enumerator[untyped, untyped]
 
+  # Creates a new Enumerator which will enumerate by calling `method` on `obj`,
+  # passing `args` if any.
+  # 
+  # If a block is given, it will be used to calculate the size of the enumerator
+  # without the need to iterate it (see Enumerator#size).
+  # 
+  # ### Examples
+  # 
+  #     str = "xyz"
+  # 
+  #     enum = str.enum_for(:each_byte)
+  #     enum.each { |b| puts b }
+  #     # => 120
+  #     # => 121
+  #     # => 122
+  # 
+  #     # protect an array from being modified by some_method
+  #     a = [1, 2, 3]
+  #     some_method(a.to_enum)
+  # 
+  # It is typical to call to_enum when defining methods for a generic Enumerable,
+  # in case no block is passed.
+  # 
+  # Here is such an example, with parameter passing and a sizing block:
+  # 
+  #     module Enumerable
+  #       # a generic method to repeat the values of any enumerable
+  #       def repeat(n)
+  #         raise ArgumentError, "#{n} is negative!" if n < 0
+  #         unless block_given?
+  #           return to_enum(__method__, n) do # __method__ is :repeat here
+  #             sz = size     # Call size and multiply by n...
+  #             sz * n if sz  # but return nil if size itself is nil
+  #           end
+  #         end
+  #         each do |*val|
+  #           n.times { yield *val }
+  #         end
+  #       end
+  #     end
+  # 
+  #     %i[hello world].repeat(2) { |w| puts w }
+  #       # => Prints 'hello', 'hello', 'world', 'world'
+  #     enum = (1..14).repeat(3)
+  #       # => returns an Enumerator when called without a block
+  #     enum.first(4) # => [1, 1, 1, 2]
+  #     enum.size # => 42
+  # 
   alias to_enum enum_for
 
+  # Equality --- At the `Object` level, `==` returns `true` only if `obj` and
+  # `other` are the same object. Typically, this method is overridden in
+  # descendant classes to provide class-specific meaning.
+  # 
+  # Unlike `==`, the `equal?` method should never be overridden by subclasses as
+  # it is used to determine object identity (that is, `a.equal?(b)` if and only if
+  # `a` is the same object as `b`):
+  # 
+  #     obj = "a"
+  #     other = obj.dup
+  # 
+  #     obj == other      #=> true
+  #     obj.equal? other  #=> false
+  #     obj.equal? obj    #=> true
+  # 
+  # The `eql?` method returns `true` if `obj` and `other` refer to the same hash
+  # key.  This is used by Hash to test members for equality.  For objects of class
+  # `Object`, `eql?` is synonymous with `==`.  Subclasses normally continue this
+  # tradition by aliasing `eql?` to their overridden `==` method, but there are
+  # exceptions.  `Numeric` types, for example, perform type conversion across
+  # `==`, but not across `eql?`, so:
+  # 
+  #     1 == 1.0     #=> true
+  #     1.eql? 1.0   #=> false
+  # 
   def eql?: (untyped) -> bool
 
+  # Adds to *obj* the instance methods from each module given as a parameter.
+  # 
+  #     module Mod
+  #       def hello
+  #         "Hello from Mod.\n"
+  #       end
+  #     end
+  # 
+  #     class Klass
+  #       def hello
+  #         "Hello from Klass.\n"
+  #       end
+  #     end
+  # 
+  #     k = Klass.new
+  #     k.hello         #=> "Hello from Klass.\n"
+  #     k.extend(Mod)   #=> #<Klass:0x401b3bc8>
+  #     k.hello         #=> "Hello from Mod.\n"
+  # 
   def `extend`: (*Module) -> self
 
+  # Prevents further modifications to *obj*. A `RuntimeError` will be raised if
+  # modification is attempted. There is no way to unfreeze a frozen object. See
+  # also `Object#frozen?`.
+  # 
+  # This method returns self.
+  # 
+  #     a = [ "a", "b", "c" ]
+  #     a.freeze
+  #     a << "z"
+  # 
+  # *produces:*
+  # 
+  #     prog.rb:3:in `<<': can't modify frozen Array (FrozenError)
+  #      from prog.rb:3
+  # 
+  # Objects of the following classes are always frozen: Integer, Float, Symbol.
+  # 
   def freeze: () -> self
 
-  def frozen: () -> bool
+  # Returns the freeze status of *obj*.
+  # 
+  #     a = [ "a", "b", "c" ]
+  #     a.freeze    #=> ["a", "b", "c"]
+  #     a.frozen?   #=> true
+  # 
+  def frozen?: () -> bool
 
   def hash: () -> Integer
 
+  # Returns a string containing a human-readable representation of *obj*. The
+  # default `inspect` shows the object's class name, an encoding of the object id,
+  # and a list of the instance variables and their values (by calling #inspect on
+  # each of them). User defined classes should override this method to provide a
+  # better representation of *obj*.  When overriding this method, it should return
+  # a string whose encoding is compatible with the default external encoding.
+  # 
+  #     [ 1, 2, 3..4, 'five' ].inspect   #=> "[1, 2, 3..4, \"five\"]"
+  #     Time.new.inspect                 #=> "2008-03-08 19:43:39 +0900"
+  # 
+  #     class Foo
+  #     end
+  #     Foo.new.inspect                  #=> "#<Foo:0x0300c868>"
+  # 
+  #     class Bar
+  #       def initialize
+  #         @bar = 1
+  #       end
+  #     end
+  #     Bar.new.inspect                  #=> "#<Bar:0x0300c868 @bar=1>"
+  # 
   def inspect: () -> String
 
+  # Returns `true` if *obj* is an instance of the given class. See also
+  # `Object#kind_of?`.
+  # 
+  #     class A;     end
+  #     class B < A; end
+  #     class C < B; end
+  # 
+  #     b = B.new
+  #     b.instance_of? A   #=> false
+  #     b.instance_of? B   #=> true
+  #     b.instance_of? C   #=> false
+  # 
   def instance_of?: (Module) -> bool
 
+  # Returns `true` if the given instance variable is defined in *obj*. String
+  # arguments are converted to symbols.
+  # 
+  #     class Fred
+  #       def initialize(p1, p2)
+  #         @a, @b = p1, p2
+  #       end
+  #     end
+  #     fred = Fred.new('cat', 99)
+  #     fred.instance_variable_defined?(:@a)    #=> true
+  #     fred.instance_variable_defined?("@b")   #=> true
+  #     fred.instance_variable_defined?("@c")   #=> false
+  # 
   def instance_variable_defined?: (String | Symbol var) -> bool
 
+  # Returns the value of the given instance variable, or nil if the instance
+  # variable is not set. The `@` part of the variable name should be included for
+  # regular instance variables. Throws a `NameError` exception if the supplied
+  # symbol is not valid as an instance variable name. String arguments are
+  # converted to symbols.
+  # 
+  #     class Fred
+  #       def initialize(p1, p2)
+  #         @a, @b = p1, p2
+  #       end
+  #     end
+  #     fred = Fred.new('cat', 99)
+  #     fred.instance_variable_get(:@a)    #=> "cat"
+  #     fred.instance_variable_get("@b")   #=> 99
+  # 
   def instance_variable_get: (String | Symbol var) -> untyped
 
+  # Sets the instance variable named by *symbol* to the given object, thereby
+  # frustrating the efforts of the class's author to attempt to provide proper
+  # encapsulation. The variable does not have to exist prior to this call. If the
+  # instance variable name is passed as a string, that string is converted to a
+  # symbol.
+  # 
+  #     class Fred
+  #       def initialize(p1, p2)
+  #         @a, @b = p1, p2
+  #       end
+  #     end
+  #     fred = Fred.new('cat', 99)
+  #     fred.instance_variable_set(:@a, 'dog')   #=> "dog"
+  #     fred.instance_variable_set(:@c, 'cat')   #=> "cat"
+  #     fred.inspect                             #=> "#<Fred:0x401b3da8 @a=\"dog\", @b=99, @c=\"cat\">"
+  # 
   def instance_variable_set: [X] (String | Symbol var, X value) -> X
 
+  # Returns an array of instance variable names for the receiver. Note that simply
+  # defining an accessor does not create the corresponding instance variable.
+  # 
+  #     class Fred
+  #       attr_accessor :a1
+  #       def initialize
+  #         @iv = 3
+  #       end
+  #     end
+  #     Fred.new.instance_variables   #=> [:@iv]
+  # 
   def instance_variables: () -> Array[Symbol]
 
+  # Returns `true` if *class* is the class of *obj*, or if *class* is one of the
+  # superclasses of *obj* or modules included in *obj*.
+  # 
+  #     module M;    end
+  #     class A
+  #       include M
+  #     end
+  #     class B < A; end
+  #     class C < B; end
+  # 
+  #     b = B.new
+  #     b.is_a? A          #=> true
+  #     b.is_a? B          #=> true
+  #     b.is_a? C          #=> false
+  #     b.is_a? M          #=> true
+  # 
+  #     b.kind_of? A       #=> true
+  #     b.kind_of? B       #=> true
+  #     b.kind_of? C       #=> false
+  #     b.kind_of? M       #=> true
+  # 
   def is_a?: (Module) -> bool
 
+  # Returns `true` if *class* is the class of *obj*, or if *class* is one of the
+  # superclasses of *obj* or modules included in *obj*.
+  # 
+  #     module M;    end
+  #     class A
+  #       include M
+  #     end
+  #     class B < A; end
+  #     class C < B; end
+  # 
+  #     b = B.new
+  #     b.is_a? A          #=> true
+  #     b.is_a? B          #=> true
+  #     b.is_a? C          #=> false
+  #     b.is_a? M          #=> true
+  # 
+  #     b.kind_of? A       #=> true
+  #     b.kind_of? B       #=> true
+  #     b.kind_of? C       #=> false
+  #     b.kind_of? M       #=> true
+  # 
   alias kind_of? is_a?
 
-  def itself: () -> self
+  # Returns the receiver.
+  # 
+  #     string = "my string"
+  #     string.itself.object_id == string.object_id   #=> true
+  # 
+  def `itself`: () -> self
 
+  # Looks up the named method as a receiver in *obj*, returning a `Method` object
+  # (or raising `NameError`). The `Method` object acts as a closure in *obj*'s
+  # object instance, so instance variables and the value of `self` remain
+  # available.
+  # 
+  #     class Demo
+  #       def initialize(n)
+  #         @iv = n
+  #       end
+  #       def hello()
+  #         "Hello, @iv = #{@iv}"
+  #       end
+  #     end
+  # 
+  #     k = Demo.new(99)
+  #     m = k.method(:hello)
+  #     m.call   #=> "Hello, @iv = 99"
+  # 
+  #     l = Demo.new('Fred')
+  #     m = l.method("hello")
+  #     m.call   #=> "Hello, @iv = Fred"
+  # 
+  # Note that `Method` implements `to_proc` method, which means it can be used
+  # with iterators.
+  # 
+  #     [ 1, 2, 3 ].each(&method(:puts)) # => prints 3 lines to stdout
+  # 
+  #     out = File.open('test.txt', 'w')
+  #     [ 1, 2, 3 ].each(&out.method(:puts)) # => prints 3 lines to file
+  # 
+  #     require 'date'
+  #     %w[2017-03-01 2017-03-02].collect(&Date.method(:parse))
+  #     #=> [#<Date: 2017-03-01 ((2457814j,0s,0n),+0s,2299161j)>, #<Date: 2017-03-02 ((2457815j,0s,0n),+0s,2299161j)>]
+  # 
   def method: (String | Symbol name) -> Method
 
+  # Returns a list of the names of public and protected methods of *obj*. This
+  # will include all the methods accessible in *obj*'s ancestors. If the optional
+  # parameter is `false`, it returns an array of *obj<i>'s public and protected
+  # singleton methods, the array will not include methods in modules included in
+  # <i>obj*.
+  # 
+  #     class Klass
+  #       def klass_method()
+  #       end
+  #     end
+  #     k = Klass.new
+  #     k.methods[0..9]    #=> [:klass_method, :nil?, :===,
+  #                        #    :==~, :!, :eql?
+  #                        #    :hash, :<=>, :class, :singleton_class]
+  #     k.methods.length   #=> 56
+  # 
+  #     k.methods(false)   #=> []
+  #     def k.singleton_method; end
+  #     k.methods(false)   #=> [:singleton_method]
+  # 
+  #     module M123; def m123; end end
+  #     k.extend M123
+  #     k.methods(false)   #=> [:singleton_method]
+  # 
   def methods: () -> Array[Symbol]
 
-  def nil?: () -> bool
+  # Only the object *nil* responds `true` to `nil?`.
+  # 
+  #     Object.new.nil?   #=> false
+  #     nil.nil?          #=> true
+  # 
+  def `nil?`: () -> bool
 
+  # Returns an integer identifier for `obj`.
+  # 
+  # The same number will be returned on all calls to `object_id` for a given
+  # object, and no two active objects will share an id.
+  # 
+  # Note: that some objects of builtin classes are reused for optimization. This
+  # is the case for immediate values and frozen string literals.
+  # 
+  # Immediate values are not passed by reference but are passed by value: `nil`,
+  # `true`, `false`, Fixnums, Symbols, and some Floats.
+  # 
+  #     Object.new.object_id  == Object.new.object_id  # => false
+  #     (21 * 2).object_id    == (21 * 2).object_id    # => true
+  #     "hello".object_id     == "hello".object_id     # => false
+  #     "hi".freeze.object_id == "hi".freeze.object_id # => true
+  # 
   def object_id: () -> Integer
 
+  # Returns the list of private methods accessible to *obj*. If the *all*
+  # parameter is set to `false`, only those methods in the receiver will be
+  # listed.
+  # 
   def private_methods: () -> Array[Symbol]
 
+  # Returns the list of protected methods accessible to *obj*. If the *all*
+  # parameter is set to `false`, only those methods in the receiver will be
+  # listed.
+  # 
   def protected_methods: () -> Array[Symbol]
 
+  # Similar to *method*, searches public method only.
+  # 
   def public_method: (name name) -> Method
 
-  def public_send: (name name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
+  # Invokes the method identified by *symbol*, passing it any arguments specified.
+  # Unlike send, public_send calls public methods only. When the method is
+  # identified by a string, the string is converted to a symbol.
+  # 
+  #     1.public_send(:puts, "hello")  # causes NoMethodError
+  # 
+  def `public_send`: (name name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
 
+  # Removes the named instance variable from *obj*, returning that variable's
+  # value. String arguments are converted to symbols.
+  # 
+  #     class Dummy
+  #       attr_reader :var
+  #       def initialize
+  #         @var = 99
+  #       end
+  #       def remove
+  #         remove_instance_variable(:@var)
+  #       end
+  #     end
+  #     d = Dummy.new
+  #     d.var      #=> 99
+  #     d.remove   #=> 99
+  #     d.var      #=> nil
+  # 
   def remove_instance_variable: (name name) -> untyped
 
+  # Returns `true` if *obj* responds to the given method.  Private and protected
+  # methods are included in the search only if the optional second parameter
+  # evaluates to `true`.
+  # 
+  # If the method is not implemented, as Process.fork on Windows, File.lchmod on
+  # GNU/Linux, etc., false is returned.
+  # 
+  # If the method is not defined, `respond_to_missing?` method is called and the
+  # result is returned.
+  # 
+  # When the method name parameter is given as a string, the string is converted
+  # to a symbol.
+  # 
   def respond_to?: (name name, ?bool include_all) -> bool
 
-  def send: (name name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
+  # Invokes the method identified by *symbol*, passing it any arguments specified.
+  # You can use `__send__` if the name `send` clashes with an existing method in
+  # *obj*. When the method is identified by a string, the string is converted to a
+  # symbol.
+  # 
+  #     class Klass
+  #       def hello(*args)
+  #         "Hello " + args.join(' ')
+  #       end
+  #     end
+  #     k = Klass.new
+  #     k.send :hello, "gentle", "readers"   #=> "Hello gentle readers"
+  # 
+  def `send`: (name name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
 
-  def singleton_class: () -> Class
+  # Returns the singleton class of *obj*.  This method creates a new singleton
+  # class if *obj* does not have one.
+  # 
+  # If *obj* is `nil`, `true`, or `false`, it returns NilClass, TrueClass, or
+  # FalseClass, respectively. If *obj* is an Integer, a Float or a Symbol, it
+  # raises a TypeError.
+  # 
+  #     Object.new.singleton_class  #=> #<Class:#<Object:0xb7ce1e24>>
+  #     String.singleton_class      #=> #<Class:String>
+  #     nil.singleton_class         #=> NilClass
+  # 
+  def `singleton_class`: () -> Class
 
+  # Similar to *method*, searches singleton method only.
+  # 
+  #     class Demo
+  #       def initialize(n)
+  #         @iv = n
+  #       end
+  #       def hello()
+  #         "Hello, @iv = #{@iv}"
+  #       end
+  #     end
+  # 
+  #     k = Demo.new(99)
+  #     def k.hi
+  #       "Hi, @iv = #{@iv}"
+  #     end
+  #     m = k.singleton_method(:hi)
+  #     m.call   #=> "Hi, @iv = 99"
+  #     m = k.singleton_method(:hello) #=> NameError
+  # 
   def singleton_method: (name name) -> Method
 
+  # Returns an array of the names of singleton methods for *obj*. If the optional
+  # *all* parameter is true, the list will include methods in modules included in
+  # *obj*. Only public and protected singleton methods are returned.
+  # 
+  #     module Other
+  #       def three() end
+  #     end
+  # 
+  #     class Single
+  #       def Single.four() end
+  #     end
+  # 
+  #     a = Single.new
+  # 
+  #     def a.one()
+  #     end
+  # 
+  #     class << a
+  #       include Other
+  #       def two()
+  #       end
+  #     end
+  # 
+  #     Single.singleton_methods    #=> [:four]
+  #     a.singleton_methods(false)  #=> [:two, :one]
+  #     a.singleton_methods         #=> [:two, :one, :three]
+  # 
   def singleton_methods: () -> Array[Symbol]
 
+  # Mark the object as tainted.
+  # 
+  # Objects that are marked as tainted will be restricted from various built-in
+  # methods. This is to prevent insecure data, such as command-line arguments or
+  # strings read from Kernel#gets, from inadvertently compromising the user's
+  # system.
+  # 
+  # To check whether an object is tainted, use #tainted?.
+  # 
+  # You should only untaint a tainted object if your code has inspected it and
+  # determined that it is safe. To do so use #untaint.
+  # 
   def taint: () -> self
 
+  # Deprecated method that is equivalent to #taint.
+  # 
   alias untrust taint
 
+  # Returns true if the object is tainted.
+  # 
+  # See #taint for more information.
+  # 
   def tainted?: () -> bool
 
+  # Deprecated method that is equivalent to #tainted?.
+  # 
   alias untrusted? tainted?
 
+  # Yields self to the block, and then returns self. The primary purpose of this
+  # method is to "tap into" a method chain, in order to perform operations on
+  # intermediate results within the chain.
+  # 
+  #     (1..10)                  .tap {|x| puts "original: #{x}" }
+  #       .to_a                  .tap {|x| puts "array:    #{x}" }
+  #       .select {|x| x.even? } .tap {|x| puts "evens:    #{x}" }
+  #       .map {|x| x*x }        .tap {|x| puts "squares:  #{x}" }
+  # 
   def tap: () { (self) -> void } -> self
 
-  def yield_self: [X] () { (self) -> X } -> X
+  # Yields self to the block and returns the result of the block.
+  # 
+  #     3.next.then {|x| x**x }.to_s             #=> "256"
+  #     "my string".yield_self {|s| s.upcase }   #=> "MY STRING"
+  # 
+  # Good usage for `yield_self` is value piping in method chains:
+  # 
+  #     require 'open-uri'
+  #     require 'json'
+  # 
+  #     construct_url(arguments).
+  #       yield_self {|url| open(url).read }.
+  #       yield_self {|response| JSON.parse(response) }
+  # 
+  # When called without block, the method returns `Enumerator`, which can be used,
+  # for example, for conditional circuit-breaking:
+  # 
+  #     # meets condition, no-op
+  #     1.yield_self.detect(&:odd?)            # => 1
+  #     # does not meet condition, drop value
+  #     2.yield_self.detect(&:odd?)            # => nil
+  # 
+  def `yield_self`: [X] () { (self) -> X } -> X
+                  | () -> Enumerator[self, untyped]
 
+  # Returns a string representing *obj*. The default `to_s` prints the object's
+  # class and an encoding of the object id. As a special case, the top-level
+  # object that is the initial execution context of Ruby programs returns
+  # ``main''.
+  # 
   def to_s: () -> String
 
+  # Removes the tainted mark from the object.
+  # 
+  # See #taint for more information.
+  # 
   def untaint: () -> self
 
+  # Deprecated method that is equivalent to #untaint.
+  # 
   alias trust untaint
 
+  # Yields self to the block and returns the result of the block.
+  # 
+  #     3.next.then {|x| x**x }.to_s             #=> "256"
+  #     "my string".yield_self {|s| s.upcase }   #=> "MY STRING"
+  # 
+  # Good usage for `yield_self` is value piping in method chains:
+  # 
+  #     require 'open-uri'
+  #     require 'json'
+  # 
+  #     construct_url(arguments).
+  #       yield_self {|url| open(url).read }.
+  #       yield_self {|response| JSON.parse(response) }
+  # 
+  # When called without block, the method returns `Enumerator`, which can be used,
+  # for example, for conditional circuit-breaking:
+  # 
+  #     # meets condition, no-op
+  #     1.yield_self.detect(&:odd?)            # => 1
+  #     # does not meet condition, drop value
+  #     2.yield_self.detect(&:odd?)            # => nil
+  # 
   alias then yield_self
 end
 

--- a/test/ruby/signature/cli_test.rb
+++ b/test/ruby/signature/cli_test.rb
@@ -116,6 +116,7 @@ singleton(::BasicObject)
   accessibility: public
   types:
       [X] () { (self) -> X } -> X
+    | () -> ::Enumerator[self, untyped]
       EOF
     end
   end


### PR DESCRIPTION
Add a tool for importing/querying RDoc, `annotate-with-rdoc` and `query-rdoc`.

* You can use `bin/annotate-with-rdoc` to import RDoc and annotate RBS files.
* You can use `bin/query-rdoc` to query RDoc to be copied to RBS files.