### PR TITLE
Remove bundler constraint

### DIFF
--- a/ruby-signature.gemspec
+++ b/ruby-signature.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "racc", "~> 1.4.15"


### PR DESCRIPTION
On Ruby 2.6, I'd like to use default bundler.gem which is 1.17.2 to avoid causing troubles on other projects. Please remove this constraint unless it's intentional.