### PR TITLE
Fix typo

### DIFF
--- a/doc/stdlib.md
+++ b/doc/stdlib.md
@@ -4,7 +4,7 @@ This is a guide for contributing to `ruby-signature` by writing/revising stdlib 
 
 ## Signatures
 
-Signatures for standard libraries are located in `stdlib` directory. `stdlib/builtin` is for builtin libraries. Other libraries have directories like `stdlibt/set` or `stdlib/pathname`.
+Signatures for standard libraries are located in `stdlib` directory. `stdlib/builtin` is for builtin libraries. Other libraries have directories like `stdlib/set` or `stdlib/pathname`.
 
 To write signatures see [syntax guide](syntax.md).
 


### PR DESCRIPTION
`stdlibt` -> `stdlib`

[![Image from Gyazo](https://i.gyazo.com/b9c93b4193f32d031250fc0b9f955edc.png)](https://gyazo.com/b9c93b4193f32d031250fc0b9f955edc)