### PR TITLE
Add rubocop-rubycw

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+require: rubocop-rubycw
+AllCops:
+  TargetRubyVersion: 2.6
+  DisabledByDefault: true
+  Exclude:
+    - 'test/**/*_test.rb'
+Rubycw/Rubycw:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,5 +4,6 @@ AllCops:
   DisabledByDefault: true
   Exclude:
     - 'test/**/*_test.rb'
+    - 'vendor/bundle/**/*'
 Rubycw/Rubycw:
   Enabled: true

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ task :stdlib_test do
 end
 
 task :rubocop do
-  sh "rubocop -P"
+  sh "rubocop --parallel"
 end
 
 rule ".rb" => ".y" do |t|

--- a/Rakefile
+++ b/Rakefile
@@ -9,10 +9,14 @@ Rake::TestTask.new(:test) do |t|
   end
 end
 
-task :default => [:test, :stdlib_test]
+task :default => [:test, :stdlib_test, :rubocop]
 
 task :stdlib_test do
   sh "ruby bin/test_runner.rb"
+end
+
+task :rubocop do
+  sh "rubocop -P"
 end
 
 rule ".rb" => ".y" do |t|

--- a/ruby-signature.gemspec
+++ b/ruby-signature.gemspec
@@ -38,5 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "racc", "~> 1.4.15"
+  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "rubocop-rubycw"
   spec.add_development_dependency "minitest-reporters", "~> 1.3.6"
 end


### PR DESCRIPTION
to ensure no warning, such as:
https://github.com/ruby/ruby-signature/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+warning