### PR TITLE
Ignore generated file from RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,5 +5,6 @@ AllCops:
   Exclude:
     - 'test/**/*_test.rb'
     - 'vendor/bundle/**/*'
+    - lib/ruby/signature/parser.rb
 Rubycw/Rubycw:
   Enabled: true


### PR DESCRIPTION
rubocop-rubycw has been introduced by #113, but it records offenses in my local.

```bash
$ bundle exec rake rubocop
Inspecting 44 files
...........................C................

Offenses:

lib/ruby/signature/parser.rb:2988:1: C: Rubycw/Rubycw: mismatched indentations at 'end' with 'module' at 9
    end   # module Signature
^
lib/ruby/signature/parser.rb:2989:1: C: Rubycw/Rubycw: mismatched indentations at 'end' with 'module' at 8
  end   # module Ruby
^

44 files inspected, 2 offenses detected
```


So this pull request suppresses the warnings by adding the generated file to the exclude list.


---


By the way, I'm not sure why the cop does not add offense on Travis CI. The builds are green on the master and other pull requests.
