### PR TITLE
Update racc

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,5 @@ AllCops:
   Exclude:
     - 'test/**/*_test.rb'
     - 'vendor/bundle/**/*'
-    - lib/ruby/signature/parser.rb
 Rubycw/Rubycw:
   Enabled: true

--- a/ruby-signature.gemspec
+++ b/ruby-signature.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "racc", "~> 1.4.15"
+  spec.add_development_dependency "racc", "~> 1.4.16"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "rubocop-rubycw"
   spec.add_development_dependency "minitest-reporters", "~> 1.3.6"


### PR DESCRIPTION
I fix the warning.
https://github.com/ruby/racc/commit/b0431d4c91aa8bd90f66ecd2f348ada096d7ef65#diff-691c91a72009483e9d5c04fae13e9953