### PR TITLE
Import visibility from runtime

### DIFF
--- a/lib/ruby/signature/prototype/runtime.rb
+++ b/lib/ruby/signature/prototype/runtime.rb
@@ -141,28 +141,61 @@ module Ruby
             end
           end
 
-          mod.instance_methods(false).sort.each do |name|
-            method = mod.instance_method(name)
+          unless mod.public_instance_methods(false).empty?
+            members << AST::Members::Public.new(location: nil)
 
-            if method.name == method.original_name
-              members << AST::Members::MethodDefinition.new(
-                name: method.name,
-                types: [method_type(method)],
-                kind: :instance,
-                location: nil,
-                comment: nil,
-                annotations: [],
-                attributes: []
-              )
-            else
-              members << AST::Members::Alias.new(
-                new_name: method.name,
-                old_name: method.original_name,
-                kind: :instance,
-                location: nil,
-                comment: nil,
-                annotations: [],
+            mod.public_instance_methods(false).sort.each do |name|
+              method = mod.instance_method(name)
+
+              if method.name == method.original_name
+                members << AST::Members::MethodDefinition.new(
+                  name: method.name,
+                  types: [method_type(method)],
+                  kind: :instance,
+                  location: nil,
+                  comment: nil,
+                  annotations: [],
+                  attributes: []
                 )
+              else
+                members << AST::Members::Alias.new(
+                  new_name: method.name,
+                  old_name: method.original_name,
+                  kind: :instance,
+                  location: nil,
+                  comment: nil,
+                  annotations: [],
+                  )
+              end
+            end
+          end
+
+          unless mod.private_instance_methods(false).empty?
+            members << AST::Members::Private.new(location: nil)
+
+            mod.private_instance_methods(false).sort.each do |name|
+              method = mod.instance_method(name)
+
+              if method.name == method.original_name
+                members << AST::Members::MethodDefinition.new(
+                  name: method.name,
+                  types: [method_type(method)],
+                  kind: :instance,
+                  location: nil,
+                  comment: nil,
+                  annotations: [],
+                  attributes: []
+                )
+              else
+                members << AST::Members::Alias.new(
+                  new_name: method.name,
+                  old_name: method.original_name,
+                  kind: :instance,
+                  location: nil,
+                  comment: nil,
+                  annotations: [],
+                  )
+              end
             end
           end
         end

--- a/test/ruby/signature/runtime_prototype_test.rb
+++ b/test/ruby/signature/runtime_prototype_test.rb
@@ -19,6 +19,11 @@ class Ruby::Signature::RuntimePrototypeTest < Minitest::Test
 
     alias bar foo
 
+    private
+
+    def a()
+    end
+
     def self.baz(&block)
     end
   end
@@ -36,9 +41,15 @@ class Ruby::Signature::RuntimePrototypeTest::Test < String
 
   def self.baz: () { (*untyped) -> untyped } -> untyped
 
+  public
+
   alias bar foo
 
   def foo: (untyped foo, ?untyped bar, *untyped baz, untyped a, b: untyped, ?c: untyped, **untyped) -> untyped
+
+  private
+
+  def a: () -> untyped
 end
 
 Ruby::Signature::RuntimePrototypeTest::Test::NAME: String


### PR DESCRIPTION
Now `runtime` prototype supports *public*/*private* instance methods. No support for singleton methods.