### PR TITLE
Print `arglists` from RDoc

### DIFF
--- a/bin/annotate-with-rdoc
+++ b/bin/annotate-with-rdoc
@@ -48,7 +48,17 @@ def comment_for_method(klass, method, stores:)
   method = store_for_class(klass, stores: stores)&.load_method(klass, method)
 
   if method&.documented?
-    string = format_comment(method.comment)
+    out = RDoc::Markup::Document.new
+
+    out << method.comment
+
+    if method.arglists
+      out << RDoc::Markup::Heading.new(1, "arglists")
+      arglists = method.arglists.chomp.split("\n").map {|line| line + "\n" }
+      out << RDoc::Markup::Verbatim.new(*arglists)
+    end
+
+    string = out.accept(RDoc::Markup::ToMarkdown.new)
     Ruby::Signature::AST::Comment.new(location: nil, string: string)
   end
 

--- a/bin/query-rdoc
+++ b/bin/query-rdoc
@@ -46,7 +46,17 @@ def comment_for_method(klass, method, stores:)
   method = store_for_class(klass, stores: stores)&.load_method(klass, method)
 
   if method&.documented?
-    format_comment(method.comment)
+    out = RDoc::Markup::Document.new
+
+    out << method.comment
+
+    if method.arglists
+      out << RDoc::Markup::Heading.new(1, "arglists")
+      arglists = method.arglists.chomp.split("\n").map {|line| line + "\n" }
+      out << RDoc::Markup::Verbatim.new(*arglists)
+    end
+
+    out.accept(RDoc::Markup::ToMarkdown.new)
   end
 rescue RDoc::Store::MissingFileError
   nil


### PR DESCRIPTION
`ri` command prints `arglists` like:

```
------------------------------------------------------------------------
  hsh.select {|key, value| block}   -> a_hash
  hsh.select                        -> an_enumerator
```

The information is useful for writing type signature of the method. So, `annotate-with-rdoc` and `query-rdoc` now prints the `arglists` too.

The purpose of printing the `arglists` is to help writing types. It is not intended to include the `arglists` to RBS files finally.