### PR TITLE
Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ language: ruby
 cache: bundler
 rvm:
   - 2.6.5
+  - 2.7.0
   - ruby-head
 before_install: gem install bundler -v 2.0.1


### PR DESCRIPTION
The policy:

* The library should work with both 2.6, 2.7, and ruby-head.
* The signature targets 2.7 for now.