### PR TITLE
Fix Writer output with an empty tuple, and optional symbol literal

### DIFF
--- a/lib/ruby/signature/types.rb
+++ b/lib/ruby/signature/types.rb
@@ -330,7 +330,11 @@ module Ruby
         end
 
         def to_s(level = 0)
-          "[ #{types.join(", ")} ]"
+          if types.empty?
+            "[ ]"
+          else
+            "[ #{types.join(", ")} ]"
+          end
         end
 
         def each_type(&block)
@@ -426,7 +430,11 @@ module Ruby
         end
 
         def to_s(level = 0)
-          "#{type.to_s(1)}?"
+          if type.is_a?(Ruby::Signature::Types::Literal) && type.literal.is_a?(Symbol)
+            "#{type.to_s(1)} ?"
+          else
+            "#{type.to_s(1)}?"
+          end
         end
 
         def each_type

--- a/test/ruby/signature/types_test.rb
+++ b/test/ruby/signature/types_test.rb
@@ -8,7 +8,10 @@ class Ruby::Signature::TypesTest < Minitest::Test
   def test_to_s
     assert_equal "Array[Integer]", parse_type("Array[Integer]").to_s
     assert_equal "Array[Integer]?", parse_type("Array[Integer]?").to_s
+    assert_equal '"foo"?', parse_type('"foo" ?').to_s
+    assert_equal ":foo ?", parse_type(":foo ?").to_s
     assert_equal "[ Integer, bool? ]", parse_type("[Integer, bool?]").to_s
+    assert_equal "[ ]", parse_type("[   ]").to_s
     assert_equal "String | bool?", parse_type("String | bool?").to_s
     assert_equal "(String | bool)?", parse_type("(String | bool)?").to_s
     assert_equal "String & bool?", parse_type("String & bool?").to_s


### PR DESCRIPTION
This pull request fixes two bugs of the Writer. Empty tuple and optional symbol literal.


# empty tuple


Currently the Writer output an empty tuple with two spaces. This change reduces the spaces to one.

```
# input
[ ]

# expected
[ ]

# actual
[  ]
```


# optional symbol literal


The Writer generates wrong code with optional symbol literal.

```
# input
:foo ?

# expected
:foo ?

# actual
:foo?
```


Because symbol literal can include `?` at the end, like Ruby. The actual case has a different meaning with the input.


I guess wrapping with braces is also ok. like `(:foo)?`. But we already have the expected style code.
So I chose the style.

https://github.com/ruby/ruby-signature/blob/6dd573c0326450ebdc3308229027ab303657d601/stdlib/builtin/string.rbs#L716-L717