### PR TITLE
Add --method-owner option to `prototype runtime`

### DIFF
--- a/lib/ruby/signature/cli.rb
+++ b/lib/ruby/signature/cli.rb
@@ -419,7 +419,6 @@ module Ruby
         when "runtime"
           require_libs = []
           relative_libs = []
-          missing_only = false
           merge = false
 
           OptionParser.new do |opts|
@@ -428,9 +427,6 @@ module Ruby
             end
             opts.on("--require-relative=[LIB]") do |lib|
               relative_libs << lib
-            end
-            opts.on("--missing-only") do
-              missing_only = true
             end
             opts.on("--merge") do
               merge = true
@@ -447,7 +443,7 @@ module Ruby
           require(*require_libs) unless require_libs.empty?
           require_relative(*relative_libs) unless relative_libs.empty?
 
-          decls = Prototype::Runtime.new(patterns: args, missing_only: missing_only, env: env, merge: merge).decls
+          decls = Prototype::Runtime.new(patterns: args, env: env, merge: merge).decls
         else
           stdout.puts "Supported formats: rbi, rb, runtime"
           exit 1

--- a/lib/ruby/signature/cli.rb
+++ b/lib/ruby/signature/cli.rb
@@ -420,6 +420,7 @@ module Ruby
           require_libs = []
           relative_libs = []
           merge = false
+          owners_included = []
 
           OptionParser.new do |opts|
             opts.on("--require=[LIB]") do |lib|
@@ -430,6 +431,9 @@ module Ruby
             end
             opts.on("--merge") do
               merge = true
+            end
+            opts.on("--method-owner=[CLASS]") do |klass|
+              owners_included << klass
             end
           end.parse!(args)
 
@@ -443,7 +447,7 @@ module Ruby
           require(*require_libs) unless require_libs.empty?
           require_relative(*relative_libs) unless relative_libs.empty?
 
-          decls = Prototype::Runtime.new(patterns: args, env: env, merge: merge).decls
+          decls = Prototype::Runtime.new(patterns: args, env: env, merge: merge, owners_included: owners_included).decls
         else
           stdout.puts "Supported formats: rbi, rb, runtime"
           exit 1

--- a/lib/ruby/signature/prototype/runtime.rb
+++ b/lib/ruby/signature/prototype/runtime.rb
@@ -163,8 +163,19 @@ module Ruby
           end
         end
 
+        def target_method?(mod, instance: nil, singleton: nil)
+          case
+          when instance
+            method = mod.instance_method(instance)
+            method.owner == mod
+          when singleton
+            method = mod.singleton_class.instance_method(singleton)
+            method.owner == mod.singleton_class
+          end
+        end
+
         def generate_methods(mod, module_name, members)
-          mod.singleton_methods(false).sort.each do |name|
+          mod.singleton_methods.select {|name| target_method?(mod, singleton: name) }.sort.each do |name|
             method = mod.singleton_method(name)
 
             if method.name == method.original_name
@@ -193,7 +204,7 @@ module Ruby
             end
           end
 
-          public_instance_methods = mod.public_instance_methods(false)
+          public_instance_methods = mod.public_instance_methods.select {|name| target_method?(mod, instance: name) }
           unless public_instance_methods.empty?
             members << AST::Members::Public.new(location: nil)
 
@@ -227,7 +238,7 @@ module Ruby
             end
           end
 
-          private_instance_methods = mod.private_instance_methods(false)
+          private_instance_methods = mod.private_instance_methods.select {|name| target_method?(mod, instance: name) }
           unless private_instance_methods.empty?
             members << AST::Members::Private.new(location: nil)
 

--- a/test/ruby/signature/runtime_prototype_test.rb
+++ b/test/ruby/signature/runtime_prototype_test.rb
@@ -113,4 +113,46 @@ Ruby::Signature::RuntimePrototypeTest::TestTargets::Test::NAME: String
       end
     end
   end
+
+  module IncludeTests
+    class SuperClass
+      def foo; end
+      def self.foo; end
+    end
+
+    class ChildClass < SuperClass
+      def bar; end
+    end
+  end
+
+  def test_include_owner
+    SignatureManager.new do |manager|
+      manager.build do |env|
+        p = Runtime.new(patterns: ["Ruby::Signature::RuntimePrototypeTest::IncludeTests::*"],
+                        env: env,
+                        merge: true,
+                        owners_included: ["Ruby::Signature::RuntimePrototypeTest::IncludeTests::SuperClass"])
+
+        assert_write p.decls, <<-EOF
+class Ruby::Signature::RuntimePrototypeTest::IncludeTests::ChildClass < Ruby::Signature::RuntimePrototypeTest::IncludeTests::SuperClass
+  def self.foo: () -> untyped
+
+  public
+
+  def bar: () -> untyped
+
+  def foo: () -> untyped
+end
+
+class Ruby::Signature::RuntimePrototypeTest::IncludeTests::SuperClass
+  def self.foo: () -> untyped
+
+  public
+
+  def foo: () -> untyped
+end
+        EOF
+      end
+    end
+  end
 end

--- a/test/ruby/signature/runtime_prototype_test.rb
+++ b/test/ruby/signature/runtime_prototype_test.rb
@@ -6,43 +6,45 @@ class Ruby::Signature::RuntimePrototypeTest < Minitest::Test
 
   include TestHelper
 
-  module Foo
-    include Enumerable
-  end
-
-  class Test < String
-    include Foo
-
-    NAME = "Hello"
-
-    def foo(foo, bar=1, *baz, a, b:, c: nil, **d)
+  module TestTargets
+    module Foo
+      include Enumerable
     end
 
-    alias bar foo
+    class Test < String
+      include Foo
 
-    private
+      NAME = "Hello"
 
-    def a()
-    end
+      def foo(foo, bar=1, *baz, a, b:, c: nil, **d)
+      end
 
-    def self.baz(&block)
-    end
+      alias bar foo
 
-    def self.b()
+      private
+
+      def a()
+      end
+
+      def self.baz(&block)
+      end
+
+      def self.b()
+      end
     end
   end
 
   def test_1
     SignatureManager.new do |manager|
       manager.build do |env|
-        p = Runtime.new(patterns: ["Ruby::Signature::RuntimePrototypeTest::*"], env: env, merge: false)
+        p = Runtime.new(patterns: ["Ruby::Signature::RuntimePrototypeTest::TestTargets::*"], env: env, merge: false)
 
         assert_write p.decls, <<-EOF
-module Ruby::Signature::RuntimePrototypeTest::Foo
+module Ruby::Signature::RuntimePrototypeTest::TestTargets::Foo
   include Enumerable
 end
 
-class Ruby::Signature::RuntimePrototypeTest::Test < String
+class Ruby::Signature::RuntimePrototypeTest::TestTargets::Test < String
   include Foo
 
   def self.b: () -> untyped
@@ -60,7 +62,7 @@ class Ruby::Signature::RuntimePrototypeTest::Test < String
   def a: () -> untyped
 end
 
-Ruby::Signature::RuntimePrototypeTest::Test::NAME: String
+Ruby::Signature::RuntimePrototypeTest::TestTargets::Test::NAME: String
     EOF
       end
     end 
@@ -69,7 +71,7 @@ Ruby::Signature::RuntimePrototypeTest::Test::NAME: String
   def test_merge_types
     SignatureManager.new do |manager|
       manager.files[Pathname("foo.rbs")] = <<EOF
-class Ruby::Signature::RuntimePrototypeTest::Test
+class Ruby::Signature::RuntimePrototypeTest::TestTargets::Test
   def self.baz: () -> void
 
   def foo: (String) -> Integer
@@ -80,14 +82,14 @@ end
 EOF
 
       manager.build do |env|
-        p = Runtime.new(patterns: ["Ruby::Signature::RuntimePrototypeTest::*"], env: env, merge: true)
+        p = Runtime.new(patterns: ["Ruby::Signature::RuntimePrototypeTest::TestTargets::*"], env: env, merge: true)
 
         assert_write p.decls, <<-EOF
-module Ruby::Signature::RuntimePrototypeTest::Foo
+module Ruby::Signature::RuntimePrototypeTest::TestTargets::Foo
   include Enumerable
 end
 
-class Ruby::Signature::RuntimePrototypeTest::Test < String
+class Ruby::Signature::RuntimePrototypeTest::TestTargets::Test < String
   include Foo
 
   def self.b: () -> untyped
@@ -106,7 +108,7 @@ class Ruby::Signature::RuntimePrototypeTest::Test < String
   def a: () -> untyped
 end
 
-Ruby::Signature::RuntimePrototypeTest::Test::NAME: String
+Ruby::Signature::RuntimePrototypeTest::TestTargets::Test::NAME: String
         EOF
       end
     end

--- a/test/ruby/signature/runtime_prototype_test.rb
+++ b/test/ruby/signature/runtime_prototype_test.rb
@@ -33,9 +33,11 @@ class Ruby::Signature::RuntimePrototypeTest < Minitest::Test
   end
 
   def test_1
-    p = Runtime.new(patterns: ["Ruby::Signature::RuntimePrototypeTest::*"], env: nil, missing_only: false, merge: false)
+    SignatureManager.new do |manager|
+      manager.build do |env|
+        p = Runtime.new(patterns: ["Ruby::Signature::RuntimePrototypeTest::*"], env: env, merge: false)
 
-    assert_write p.decls, <<-EOF
+        assert_write p.decls, <<-EOF
 module Ruby::Signature::RuntimePrototypeTest::Foo
   include Enumerable
 end
@@ -60,42 +62,8 @@ end
 
 Ruby::Signature::RuntimePrototypeTest::Test::NAME: String
     EOF
-  end
-
-  def test_missing_only
-    SignatureManager.new do |manager|
-      manager.files[Pathname("foo.rbs")] = <<EOF
-class Ruby::Signature::RuntimePrototypeTest::Test
-  def self.baz: () -> void
-
-  def foo: () -> void
-
-  def bar: () -> void
-end
-EOF
-
-      manager.build do |env|
-        p = Runtime.new(patterns: ["Ruby::Signature::RuntimePrototypeTest::*"], env: env, missing_only: true, merge: false)
-
-        assert_write p.decls, <<-EOF
-module Ruby::Signature::RuntimePrototypeTest::Foo
-  include Enumerable
-end
-
-class Ruby::Signature::RuntimePrototypeTest::Test < String
-  include Foo
-
-  def self.b: () -> untyped
-
-  private
-
-  def a: () -> untyped
-end
-
-Ruby::Signature::RuntimePrototypeTest::Test::NAME: String
-        EOF
       end
-    end
+    end 
   end
 
   def test_merge_types
@@ -112,7 +80,7 @@ end
 EOF
 
       manager.build do |env|
-        p = Runtime.new(patterns: ["Ruby::Signature::RuntimePrototypeTest::*"], env: env, missing_only: false, merge: true)
+        p = Runtime.new(patterns: ["Ruby::Signature::RuntimePrototypeTest::*"], env: env, merge: true)
 
         assert_write p.decls, <<-EOF
 module Ruby::Signature::RuntimePrototypeTest::Foo


### PR DESCRIPTION
Usually, `prototype runtime` prints only methods which `owner` is the target module. `--method-owner` allows to print extra methods owned by other modules.

```
$ rbs prototype runtime Integer       # Print only Integer class methods
$ rbs prototype runtime --method-owner=Numeric Integer    # Print Integer methods and Numeric methods
```