### PR TITLE
Bug fix and Refactoring for `hash`, `==`, and `eql?` methods

### DIFF
--- a/lib/ruby/signature/ast/declarations.rb
+++ b/lib/ruby/signature/ast/declarations.rb
@@ -121,7 +121,7 @@ module Ruby
           alias eql? ==
 
           def hash
-            self.class.hash ^ name.hash ^ type_params.hash ^ super_class.hash ^ member.hash
+            self.class.hash ^ name.hash ^ type_params.hash ^ super_class.hash ^ members.hash
           end
 
           def to_json(*a)

--- a/lib/ruby/signature/ast/members.rb
+++ b/lib/ruby/signature/ast/members.rb
@@ -335,7 +335,7 @@ module Ruby
           alias eql? ==
 
           def hash
-            self.class.hash ^ new_name.hash ^ old_name.hash ^ kind
+            self.class.hash ^ new_name.hash ^ old_name.hash ^ kind.hash
           end
 
           def to_json(*a)


### PR DESCRIPTION
This change fixes bugs of `hash` method, and refactors definition of `==` and `eql?` methods.


# bug fix for `hash` method

977d9e350233c5271886d8415def19ea8ffd89a0


Currently `hash` method of `Ruby::Signature::AST::Declarations::Class` and `Ruby::Signature::AST::Members::Alias` raise an error.


```ruby
irb(main):008:0> Ruby::Signature::Parser.parse_signature('class C end').first.hash
Traceback (most recent call last):
        3: from bin/console:14:in `<main>'
        2: from (irb):8
        1: from /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/ast/declarations.rb:124:in `hash'
NameError (undefined local variable or method `member' for #<Ruby::Signature::AST::Declarations::Class:0x00005567cf7f47c0>)
Did you mean?  members
               @members
irb(main):009:0> Ruby::Signature::Parser.parse_signature('class C alias a b end ').first.members.first.hash
Traceback (most recent call last):
        5: from bin/console:14:in `<main>'
        4: from (irb):8
        3: from (irb):9:in `rescue in irb_binding'
        2: from /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/ast/members.rb:338:in `hash'
        1: from /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/ast/members.rb:338:in `^'
TypeError (:instance can't be coerced into Integer)
```




# refactor

This change was reverted.

0b3f67cad9077a13ad281fb2ec61627984eed82d

~Currently we have many redundant codes to define `==` and `eql?`.~
~This change extracts them to `Equivalence` module.~


~It avoids making redundant code, and bug of `hash` method like the above.~