### PR TITLE
Improve rbs command help message

### DIFF
--- a/lib/ruby/signature/cli.rb
+++ b/lib/ruby/signature/cli.rb
@@ -70,22 +70,23 @@ module Ruby
       def run(args)
         options = LibraryOptions.new
 
-        OptionParser.new do |opts|
-          library_parse(opts, options: options)
-          parse_logging_options(opts)
-        end.order!(args)
+        opts = OptionParser.new
+        opts.banner = <<~USAGE
+          Usage: rbs [options] COMMAND
+          Available commands: #{COMMANDS.join(", ")}
+        USAGE
+        library_parse(opts, options: options)
+        parse_logging_options(opts)
+
+        opts.order!(args)
 
         command = args.shift&.to_sym
 
         if COMMANDS.include?(command)
           __send__ :"run_#{command}", args, options
         else
-          run_help()
+          stdout.puts opts.help
         end
-      end
-
-      def run_help
-        stdout.puts "Available commands: #{COMMANDS.join(", ")}"
       end
 
       def run_ast(args, options)


### PR DESCRIPTION
This pull request has two improvements for the CLI help message.

First, it will add "Available commands" to `--help` message.

Second, it will change the help message when it receives an unknown subcommand.
Currently it only prints available commands. But it will be the same as `--help`.


I think the changes are useful to understand `rbs` command.



# before

```bash
$ exe/rbs --help
Usage: rbs [options]
    -r LIBRARY
    -I DIR
        --no-stdlib
        --log-level=LEVEL            Specify log level (defaults to `warn`)
        --log-output=OUTPUT          Specify the file to output log (defaults to stderr)

$ exe/rbs unknown-subcommand
Available commands: ast, list, ancestors, methods, method, validate, constant, paths, prototype, version
```


# after


```bash
$ exe/rbs --help
Usage: rbs [options] COMMAND
Available commands: ast, list, ancestors, methods, method, validate, constant, paths, prototype, version
    -r LIBRARY
    -I DIR
        --no-stdlib
        --log-level=LEVEL            Specify log level (defaults to `warn`)
        --log-output=OUTPUT          Specify the file to output log (defaults to stderr)

$ exe/rbs unknown-subcommand
Usage: rbs [options] COMMAND
Available commands: ast, list, ancestors, methods, method, validate, constant, paths, prototype, version
    -r LIBRARY
    -I DIR
        --no-stdlib
        --log-level=LEVEL            Specify log level (defaults to `warn`)
        --log-output=OUTPUT          Specify the file to output log (defaults to stderr)
```