### PR TITLE
Fix `rbs prototype rb` command

### DIFF
--- a/lib/ruby/signature/prototype/rb.rb
+++ b/lib/ruby/signature/prototype/rb.rb
@@ -337,7 +337,7 @@ module Ruby
               )
 
               yields.each do |yield_node|
-                array_content = yield_node.children[0].children.compact
+                array_content = yield_node.children[0]&.children&.compact || []
 
                 positionals, keywords = if keyword_hash?(array_content.last)
                                           [array_content.take(array_content.size - 1), array_content.last]

--- a/lib/ruby/signature/prototype/rb.rb
+++ b/lib/ruby/signature/prototype/rb.rb
@@ -133,7 +133,7 @@ module Ruby
           when :FCALL
             if current_module
               # Inside method definition cannot reach here.
-              args = node.children[1].children
+              args = node.children[1]&.children || []
 
               case node.children[0]
               when :include

--- a/test/ruby/signature/rb_prototype_test.rb
+++ b/test/ruby/signature/rb_prototype_test.rb
@@ -233,4 +233,23 @@ G: ::Array[untyped]
 H: ::Hash[untyped, untyped]
     EOF
   end
+
+  def test_argumentless_fcall
+    parser = RB.new
+
+    rb = <<-'EOR'
+class C
+  included do
+    do_something
+  end
+end
+    EOR
+
+    parser.parse(rb)
+
+    assert_write parser.decls, <<-EOF
+class C
+end
+    EOF
+  end
 end

--- a/test/ruby/signature/rb_prototype_test.rb
+++ b/test/ruby/signature/rb_prototype_test.rb
@@ -42,6 +42,7 @@ class Hello
   end
 
   def self.world
+    yield
     yield 1, x: 3
     yield 1, 2, x: 3, y: 2
     yield 1, 2, 'hello' => world 


### PR DESCRIPTION
I'm trying to use `rbs prototype rb`command for a real Rails application, but I got errors.

Currently this pull request fixes two problems. The command successfully finished with the changes.
But it still has a problem. The generated signature has syntax error(s).

So I'll mark this pull request reviewable after fixing the remaining bugs.


# Problems

## arguemnt-less FCALL

FCALL node can be argument-less, but the command does not treat that case.

```ruby
# They're FCALLs, but without arguments.
foo() # (FCALL@1:0-1:5 :foo nil)
foo{} # (ITER@1:0-1:5 (FCALL@1:0-1:3 :foo nil) (SCOPE@1:3-1:5 tbl: [] args: nil body: (BEGIN@1:4-1:4 nil)))
```

I met the bug with `included` in the Rails application.

```ruby
class C
  included do
    def foo
    end
  end
end
```



## argument-less yield

`yield` also can be argument-less, but it does not treat.

```ruby
def foo
  yield
end
```