### PR TITLE
Accept keyword as var name opt

### DIFF
--- a/lib/ruby/signature/parser.y
+++ b/lib/ruby/signature/parser.y
@@ -7,7 +7,7 @@ class Ruby::Signature::Parser
         kVOID kNIL kTRUE kFALSE kANY kUNTYPED kTOP kBOT kSELF kSELFQ kINSTANCE kCLASS kBOOL kSINGLETON kTYPE kDEF kMODULE kSUPER
         kPRIVATE kPUBLIC kALIAS
         kCOLON kCOLON2 kCOMMA kBAR kAMP kHAT kARROW kQUESTION kEXCLAMATION kSTAR kSTAR2 kFATARROW kEQ kDOT kLT
-        kINTERFACE kEND kINCLUDE kEXTEND kATTRREADER kATTRWRITER kATTRACCESSOR tOPERATOR tQUOTEDMETHOD
+        kINTERFACE kEND kINCLUDE kEXTEND kATTRREADER kATTRWRITER kATTRACCESSOR tOPERATOR tQUOTEDMETHOD tQUOTEDIDENT
         kPREPEND kEXTENSION kINCOMPATIBLE
         type_TYPE type_SIGNATURE type_METHODTYPE tEOF
         kOUT kIN kUNCHECKED
@@ -497,6 +497,7 @@ rule
                                   location: val[0].location + val[1].location)
       }
     | tQUOTEDMETHOD
+    | tQUOTEDIDENT
     | tWRITE_ATTR
 
   method_name0: tUIDENT | tLIDENT | identifier_keywords
@@ -941,7 +942,7 @@ rule
       }
 
   var_name_opt:
-    | tLIDENT | tINTERFACEIDENT
+    | tLIDENT | tINTERFACEIDENT | tQUOTEDIDENT
 
   qualified_name:
       namespace simple_name {
@@ -1261,6 +1262,9 @@ def next_token
   when eof_re && input.scan(eof_re)
     @eof = true
     [:tEOF, input.matched]
+  when input.scan(/`[a-zA-Z_]\w*`/)
+    s = input.matched.yield_self {|s| s[1, s.length-2] }
+    new_token(:tQUOTEDIDENT, s)
   when input.scan(/`(\\`|[^` :])+`/)
     s = input.matched.yield_self {|s| s[1, s.length-2] }.gsub(/\\`/, '`')
     new_token(:tQUOTEDMETHOD, s)

--- a/lib/ruby/signature/types.rb
+++ b/lib/ruby/signature/types.rb
@@ -603,7 +603,11 @@ module Ruby
 
           def to_s
             if name
-              "#{type} #{name}"
+              if /\A#{Parser::KEYWORDS_RE}\z/.match?(name)
+                "#{type} `#{name}`"
+              else
+                "#{type} #{name}"
+              end
             else
               "#{type}"
             end

--- a/lib/ruby/signature/writer.rb
+++ b/lib/ruby/signature/writer.rb
@@ -203,7 +203,7 @@ module Ruby
       def method_name(name)
         s = name.to_s
 
-        if s =~ Parser::KEYWORDS_RE
+        if /\A#{Parser::KEYWORDS_RE}\z/.match?(s)
           "`#{s}`"
         else
           s

--- a/test/ruby/signature/signature_parsing_test.rb
+++ b/test/ruby/signature/signature_parsing_test.rb
@@ -753,6 +753,7 @@ end
       <<-EOS
 class X
   def foo: (type: untyped, class: untyped, module: untyped, if: untyped, include: untyped, yield: untyped, def: untyped, self: untyped, instance: untyped, any: untyped, void: void) -> untyped
+  def bar: (untyped `type`, void: untyped `void`) -> untyped
 end
       EOS
     end

--- a/test/ruby/signature/types_test.rb
+++ b/test/ruby/signature/types_test.rb
@@ -22,5 +22,6 @@ class Ruby::Signature::TypesTest < Minitest::Test
     assert_equal "((Integer | String) & bool)?", parse_type("((Integer | String) & bool)?").to_s
     assert_equal "^() -> void", parse_type("^() -> void").to_s
     assert_equal "^(bool flag, ?untyped, *Symbol, name: String, ?email: nil, **Symbol) -> void", parse_type("^(bool flag, ?untyped, *Symbol, name: String, ?email: nil, **Symbol) -> void").to_s
+    assert_equal "^(untyped `untyped`, untyped footype) -> void", parse_type("^(untyped `untyped`, untyped footype) -> void").to_s
   end
 end

--- a/test/ruby/signature/writer_test.rb
+++ b/test/ruby/signature/writer_test.rb
@@ -114,6 +114,8 @@ interface _Each[X, Y]
 
   def `def`: () -> Symbol
 
+  def timeout: () -> Integer
+
   def `: (String) -> untyped
 end
     SIG


### PR DESCRIPTION
Fix #154


This pull request allows you to write a keyword as an argument name with escaping by backticks.


```rbs
class C
  # ok
  def foo: (untyped `type`, void: untyped `void`) -> untyped

  # syntax error
  def bar: (untyped type, void: untyped void) -> untyped

  # syntax error
  def baz: (untyped `**`) -> untyped
end
```


This pull request also fixes the Writer to generate code with the escaping.


---



By the way, it also includes a bug fix of Writer for method name escaping.
https://github.com/ruby/ruby-signature/pull/155/files#diff-5e2ea3c3d2ea351a23bbb3cddd984c7dR206

```rbs
class C
  # Currently Writer escape `timeout` with backticks, because it ends with "out" and "out" is a keyword.
  def `timeout`: () -> Integer

  # But the escaping is unnecessary!
  def timeout: () -> Integer
end
```