### PR TITLE
Support `class << self` syntax in `rbs prototype rb`

### DIFF
--- a/test/ruby/signature/rb_prototype_test.rb
+++ b/test/ruby/signature/rb_prototype_test.rb
@@ -61,6 +61,26 @@ end
     EOF
   end
 
+  def test_sclass
+    parser = RB.new
+
+    rb = <<-EOR
+class Hello
+  class << self
+    def hello() end
+  end
+end
+    EOR
+
+    parser.parse(rb)
+
+    assert_write parser.decls, <<-EOF
+class Hello
+  def self.hello: () -> untyped
+end
+    EOF
+  end
+
   def test_meta_programming
     parser = RB.new
 


### PR DESCRIPTION



Currently `rbs prototype rb` command ignores `class <<self` syntax.

```ruby
# test.rb
class C
  class << self
    def m() end
  end
  def m() end
end
```

```
$ ruby exe/rbs prototype rb test.rb
class C
  def m: () -> untyped

  def m: () -> untyped
end
```


This pull request will add the support of `class << self` syntax.

The generated rbs will be the following.

```bash
$ exe/rbs prototype rb test.rb
class C
  def self.m: () -> untyped

  def m: () -> untyped
end
```