### PR TITLE
Fix stack overflow while resolving included module by ConstantTable

### DIFF
--- a/lib/ruby/signature/constant_table.rb
+++ b/lib/ruby/signature/constant_table.rb
@@ -90,7 +90,7 @@ module Ruby
         decl.members.each do |member|
           case member
           when AST::Members::Include
-            constant_scopes_module absolute_type_name(name, namespace: namespace),
+            constant_scopes_module absolute_type_name(member.name, namespace: namespace),
                                    scopes: scopes
           end
         end

--- a/test/ruby/signature/constant_table_test.rb
+++ b/test/ruby/signature/constant_table_test.rb
@@ -127,7 +127,12 @@ EOF
 class Set
 end
 
+module Baz
+end
+Baz::X: Integer
+
 module Foo::Bar
+  include Baz
 end
 EOF
       manager.build do |env|
@@ -138,6 +143,12 @@ EOF
           assert_instance_of Constant, constant
           assert_equal "::Set", constant.name.to_s
           assert_equal 'singleton(::Set)', constant.type.to_s
+        end
+
+        table.resolve_constant_reference(TypeName.new(name: :X, namespace: Namespace.empty), context: Namespace.parse("::Foo::Bar")).tap do |constant|
+          assert_instance_of Constant, constant
+          assert_equal "::Baz::X", constant.name.to_s
+          assert_equal '::Integer', constant.type.to_s
         end
       end
     end


### PR DESCRIPTION
# Problem


When ConstantTable tries to resolve a constant that is defined in the included module, it raises a stack overflow error.

```ruby
require 'ruby/signature'


include Ruby::Signature

polyfill_decls = Parser.parse_signature <<~SIG
  class BasicObject
  end

  class Object < BasicObject
  end

  class Module
  end

  class Integer
  end
SIG

decls = Parser.parse_signature <<~SIG
  module A
  end
  A::B: Integer

  module C
    include A
  end
SIG

env = Environment.new
decls.each do |d|
  env << d
end
polyfill_decls.each do |d|
  env << d
end


name = TypeName.new(name: :B, namespace: Namespace.empty)
namespace = Namespace.parse('::C')

builder = DefinitionBuilder.new(env: env)
table = ConstantTable.new(builder: builder)
p table.resolve_constant_reference(name, context: namespace)
```

This code tries to resolve constant `B` in module `C`.


```
Traceback (most recent call last):
        10343: from test.rb:44:in `<main>'
        10342: from /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/constant_table.rb:44:in `resolve_constant_reference'
        10341: from /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/constant_table.rb:83:in `constant_scopes'
        10340: from /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/constant_table.rb:108:in `constant_scopes0'
        10339: from /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/constant_table.rb:90:in `constant_scopes_module'
        10338: from /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/constant_table.rb:90:in `each'
        10337: from /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/constant_table.rb:93:in `block in constant_scopes_module'
        10336: from /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/constant_table.rb:90:in `constant_scopes_module'
         ... 10331 levels...
            4: from /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/constant_table.rb:146:in `absolute_type_name'
            3: from /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/environment.rb:175:in `absolute_type_name'
            2: from /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/environment.rb:159:in `absolute_class_name'
            1: from /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/environment.rb:139:in `absolute_type_name_in'
/home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/type_name.rb:56:in `absolute?': stack level too deep (SystemStackError)
```


# Cause


`constant_scopes_module` method, which resolves `include`, calls itself with the same argument recursively. But it should be the called with included modules.


