### PR TITLE
Clear cache when yielded block raises an error

### DIFF
--- a/lib/ruby/signature/definition_builder.rb
+++ b/lib/ruby/signature/definition_builder.rb
@@ -808,7 +808,12 @@ module Ruby
           raise
         when nil
           cache[type_name] = false
-          cache[type_name] = yield
+          begin
+            cache[type_name] = yield
+          rescue => ex
+            cache[type_name] = nil
+            raise ex
+          end
         end
       end
 


### PR DESCRIPTION
# Problem

I got a RuntimeError when I tried using Steep.
The error is raised in the `when false` clause in `DefinitionBuilder#try_cache` method.



```
RuntimeError
  /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/definition_builder.rb:808:in `try_cache'
  /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/definition_builder.rb:241:in `build_singleton'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/type_construction.rb:255:in `for_module'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/type_construction.rb:1012:in `block (2 levels) in synthesize'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/type_construction.rb:1011:in `yield_self'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/type_construction.rb:1011:in `block in synthesize'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-5.2.4.1/lib/active_support/tagged_logging.rb:71:in `block in tagged'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-5.2.4.1/lib/active_support/tagged_logging.rb:28:in `tagged'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-5.2.4.1/lib/active_support/tagged_logging.rb:71:in `tagged'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/type_construction.rb:480:in `synthesize'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/type_construction.rb:1013:in `block (3 levels) in synthesize'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/type_construction.rb:1012:in `yield_self'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/type_construction.rb:1012:in `block (2 levels) in synthesize'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/type_construction.rb:1011:in `yield_self'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/type_construction.rb:1011:in `block in synthesize'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-5.2.4.1/lib/active_support/tagged_logging.rb:71:in `block in tagged'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-5.2.4.1/lib/active_support/tagged_logging.rb:28:in `tagged'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-5.2.4.1/lib/active_support/tagged_logging.rb:71:in `tagged'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/type_construction.rb:480:in `synthesize'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/project/file.rb:79:in `block in type_check'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/project/file.rb:96:in `parse'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/project/file.rb:48:in `type_check'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/project/target.rb:166:in `block in run_type_check'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/project/target.rb:165:in `each_value'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/project/target.rb:165:in `run_type_check'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/project/target.rb:87:in `block in type_check'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/project/target.rb:139:in `load_signatures'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/project/target.rb:86:in `type_check'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/drivers/utils/driver_helper.rb:76:in `block (2 levels) in type_check'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-5.2.4.1/lib/active_support/tagged_logging.rb:71:in `block in tagged'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-5.2.4.1/lib/active_support/tagged_logging.rb:28:in `tagged'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/activesupport-5.2.4.1/lib/active_support/tagged_logging.rb:71:in `tagged'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/drivers/utils/driver_helper.rb:75:in `block in type_check'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/drivers/utils/driver_helper.rb:74:in `each'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/drivers/utils/driver_helper.rb:74:in `type_check'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/drivers/check.rb:25:in `run'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/cli.rb:91:in `process_check'
  /home/pocke/ghq/github.com/soutaro/steep/lib/steep/cli.rb:50:in `run'
  /home/pocke/ghq/github.com/soutaro/steep/exe/steep:12:in `<top (required)>'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/bin/steep:23:in `load'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/bin/steep:23:in `<top (required)>'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/2.6.0/bundler/cli/exec.rb:74:in `load'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/2.6.0/bundler/cli/exec.rb:74:in `kernel_load'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/2.6.0/bundler/cli/exec.rb:28:in `run'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/2.6.0/bundler/cli.rb:463:in `exec'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/2.6.0/bundler/cli.rb:27:in `dispatch'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/2.6.0/bundler/cli.rb:18:in `start'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-1.17.2/exe/bundle:30:in `block in <top (required)>'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/2.6.0/bundler/friendly_errors.rb:124:in `with_friendly_errors'
  /home/pocke/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/bundler-1.17.2/exe/bundle:22:in `<top (required)>'
  /home/pocke/.rbenv/versions/2.6.4/bin/bundle:23:in `load'
  /home/pocke/.rbenv/versions/2.6.4/bin/bundle:23:in `<main>'
```


It means `try_cache` method was called, but it was called again before the cache is not warmed by the first call.


So I guessed the first `try_cache` call raised an error. And the error is cached by Steep, so the process continued.
It's the right guess. We can confirm the error with the following patch.



```diff
diff --git a/lib/ruby/signature/definition_builder.rb b/lib/ruby/signature/definition_builder.rb
index 88e8e68..a521629 100644
--- a/lib/ruby/signature/definition_builder.rb
+++ b/lib/ruby/signature/definition_builder.rb
@@ -810,6 +810,9 @@ module Ruby
           cache[type_name] = false
           cache[type_name] = yield
         end
+      rescue
+        binding.irb
+        raise
       end
 
       def build_interface(type_name, declaration)
```


Then, I got the following error. And steep continue analyzing.


```
irb(#<Ruby::Signature::DefinitionBuilder:0x000055d1109e5548>):009:0> $!
=> #<Ruby::Signature::NoTypeFoundError: sig/base.rbs:196:2...196:31: Could not find ::ActiveSupport::Concern>
```

By the way, I got the error only if the signature is incomplete. After I filled all types to signature files, I do not see the error.

# Solution


Clear cached `false` when error.

I'm not sure it is the right way.
My understanding is that the cache barrier works to avoid recursive `try_cache` calling. So I guess the error case is overlooked.
Please tell me if the understanding is worng :pray: 