### PR TITLE
Do not emit unexpected keyword rest by `rbs prototype rb`

### DIFF
--- a/lib/ruby/signature/prototype/rb.rb
+++ b/lib/ruby/signature/prototype/rb.rb
@@ -315,7 +315,7 @@ module Ruby
             end
           end
 
-          if kwrest
+          if kwrest && kwrest.children.any?
             fun = fun.update(rest_keywords: Types::Function::Param.new(name: kwrest.children[0], type: untyped))
           end
 

--- a/test/ruby/signature/rb_prototype_test.rb
+++ b/test/ruby/signature/rb_prototype_test.rb
@@ -47,6 +47,8 @@ class Hello
     yield 1, 2, x: 3, y: 2
     yield 1, 2, 'hello' => world 
   end
+
+  def kw_req(a:) end
 end
     EOR
 
@@ -57,6 +59,8 @@ class Hello
   def hello: (untyped a, ?::Integer b, *untyped c, untyped d, e: untyped e, ?f: ::Integer f, **untyped g) { () -> untyped } -> untyped
 
   def self.world: () { (untyped, untyped, untyped, x: untyped, y: untyped) -> untyped } -> untyped
+
+  def kw_req: (a: untyped a) -> untyped
 end
     EOF
   end


### PR DESCRIPTION
# Problem


`rbs prototype rb` command generates kwrest argument unexpectedly if the method as keyword argument(s).

```ruby
# a.rb
class C
  def foo(x:) end
end
```

```bash
$ exe/rbs prototype rb a.rb
# a.rb
class C
  def foo: (x: untyped x, **untyped) -> untyped
end
```


# Cause


Because a kwrest node is not falsy if the method has keyword arguments.

```ruby
pp RubyVM::AbstractSyntaxTree.parse <<~RUBY
  def with_keyword_arg(x:) end
  def without_keyowrd_arg(x) end
RUBY
```

```
(SCOPE@1:0-2:30
 tbl: []
 args: nil
 body:
   (BLOCK@1:0-2:30
      (DEFN@1:0-1:28
       mid: :with_keyword_arg
       body:
         (SCOPE@1:0-1:28
          tbl: [:x, nil]
          args:
            (ARGS@1:21-1:23
             pre_num: 0
             pre_init: nil
             opt: nil
             first_post: nil
             post_num: 0
             post_init: nil
             rest: nil
             kw:
               (KW_ARG@1:21-1:23
                  (LASGN@1:21-1:23 :x :NODE_SPECIAL_REQUIRED_KEYWORD) nil)
             kwrest: (DVAR@1:21-1:23 nil)
             block: nil)
          body: nil))
      (DEFN@2:0-2:30
       mid: :without_keyowrd_arg
       body:
         (SCOPE@2:0-2:30
          tbl: [:x]
          args:
            (ARGS@2:24-2:25
             pre_num: 1
             pre_init: nil
             opt: nil
             first_post: nil
             post_num: 0
             post_init: nil
             rest: nil
             kw: nil
             kwrest: nil
             block: nil)
          body: nil))))
```


---


This pull request will fix the problem.