### PR TITLE
Vendoring RBSs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /.ruby-version
 /lib/ruby/signature/parser.rb
 /lib/ruby/signature/parser.output
+/vendor/sigs

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ruby-signature.gemspec
 gemspec
+
+gem "ruby-signature-amber", path: "test/assets/test-gem"

--- a/lib/ruby/signature.rb
+++ b/lib/ruby/signature.rb
@@ -33,6 +33,7 @@ require "ruby/signature/prototype/rbi"
 require "ruby/signature/prototype/rb"
 require "ruby/signature/prototype/runtime"
 require "ruby/signature/environment_walker"
+require "ruby/signature/vendorer"
 
 begin
   require "ruby/signature/parser"

--- a/lib/ruby/signature/cli.rb
+++ b/lib/ruby/signature/cli.rb
@@ -23,7 +23,7 @@ module Ruby
             loader.add(path: Pathname(dir))
           end
 
-          loader.stdlib_root = nil if no_stdlib
+          loader.no_builtin! nil if no_stdlib
 
           loader
         end

--- a/lib/ruby/signature/vendorer.rb
+++ b/lib/ruby/signature/vendorer.rb
@@ -1,0 +1,49 @@
+module Ruby
+  module Signature
+    class Vendorer
+      attr_reader :vendor_dir
+
+      def initialize(vendor_dir:)
+        @vendor_dir = vendor_dir
+      end
+
+      def ensure_dir
+        unless vendor_dir.directory?
+          vendor_dir.mkpath
+        end
+
+        yield
+      end
+
+      def clean!
+        ensure_dir do
+          Signature.logger.info "Cleaning vendor root: #{vendor_dir}..."
+          vendor_dir.rmtree
+        end
+      end
+
+      def stdlib!()
+        ensure_dir do
+          Signature.logger.info "Vendoring stdlib: #{EnvironmentLoader::STDLIB_ROOT} => #{vendor_dir + "stdlib"}..."
+          FileUtils.copy_entry EnvironmentLoader::STDLIB_ROOT, vendor_dir + "stdlib"
+        end
+      end
+
+      def gem!(name, version)
+        ensure_dir do
+          sig_path = EnvironmentLoader.gem_sig_path(name, version)
+          Signature.logger.debug "Checking gem signature path: name=#{name}, version=#{version}, path=#{sig_path}"
+
+          if sig_path&.directory?
+            gems_dir = vendor_dir + "gems"
+            gems_dir.mkpath unless gems_dir.directory?
+
+            gem_dir = gems_dir + name
+            Signature.logger.info "Vendoring gem(#{name}:#{version}): #{sig_path} => #{gem_dir}..."
+            FileUtils.copy_entry sig_path, gem_dir
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/assets/test-gem/amber.gemspec
+++ b/test/assets/test-gem/amber.gemspec
@@ -1,0 +1,21 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+Gem::Specification.new do |spec|
+  spec.name          = "ruby-signature-amber"
+  spec.version       = "1.0.0"
+  spec.authors       = ["Soutaro Matsumoto"]
+  spec.email         = ["matsumoto@soutaro.com"]
+
+  spec.summary       = %q{Test Gem}
+  spec.description   = %q{Test Gem with RBS files}
+  spec.homepage      = "https://example.com"
+  spec.license       = 'MIT'
+
+  spec.files         = [
+    "lib/amber.rb",
+    "sig/amber.rbs"
+  ]
+  spec.require_paths = ["lib"]
+end

--- a/test/assets/test-gem/lib/amber.rb
+++ b/test/assets/test-gem/lib/amber.rb
@@ -1,0 +1,5 @@
+class Amber
+  def say
+    puts "Amber"
+  end
+end

--- a/test/assets/test-gem/sig/amber.rbs
+++ b/test/assets/test-gem/sig/amber.rbs
@@ -1,0 +1,3 @@
+class Amber
+  def say: () -> void
+end

--- a/test/ruby/signature/cli_test.rb
+++ b/test/ruby/signature/cli_test.rb
@@ -149,4 +149,19 @@ singleton(::BasicObject)
       assert_match %r{^sig/test \(absent\)$}, stdout.string
     end
   end
+
+  def test_vendor
+    Dir.mktmpdir do |d|
+      Dir.chdir(d) do
+        with_cli do |cli|
+          cli.run(%w(vendor --vendor-dir=dir1 --stdlib ruby-signature-amber racc))
+
+          assert_operator Pathname(d) + "dir1/stdlib", :directory?
+          assert_operator Pathname(d) + "dir1/gems", :directory?
+          assert_operator Pathname(d) + "dir1/gems/ruby-signature-amber", :directory?
+          refute_operator Pathname(d) + "dir1/gems/racc", :directory?
+        end
+      end
+    end
+  end
 end

--- a/test/ruby/signature/environment_loader_test.rb
+++ b/test/ruby/signature/environment_loader_test.rb
@@ -60,7 +60,8 @@ end
 
   def test_loading_without_stdlib
     with_signatures do |path|
-      loader = EnvironmentLoader.new(stdlib_root: nil)
+      loader = EnvironmentLoader.new()
+      loader.no_builtin!
 
       env = Environment.new
       loader.load(env: env)
@@ -98,6 +99,26 @@ end
       assert_raises EnvironmentLoader::UnknownLibraryNameError do
         loader.add(library: "racc:0.0.0")
       end
+    end
+  end
+
+  def test_gem_path_vendored
+    with_signatures do |path|
+      gem_root = path + "gems"
+      gem_root.mkdir
+
+      vendor_racc_path = gem_root + "racc"
+      vendor_racc_path.mkdir
+      (vendor_racc_path + "racc.rbs").write <<-CONTENT
+DUMMY: String
+      CONTENT
+
+      loader = EnvironmentLoader.new(gem_vendor_path: gem_root)
+
+      loader.add(library: "racc:0.0.0")
+
+      racc_path = loader.paths.find {|path| path.name == "racc" }
+      assert_equal gem_root + "racc", racc_path.path
     end
   end
 end

--- a/test/ruby/signature/vendorer_test.rb
+++ b/test/ruby/signature/vendorer_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+require "open3"
+
+class Ruby::Signature::EnvironmentLoaderTest < Minitest::Test
+  Environment = Ruby::Signature::Environment
+  EnvironmentLoader = Ruby::Signature::EnvironmentLoader
+  Declarations = Ruby::Signature::AST::Declarations
+  TypeName = Ruby::Signature::TypeName
+  Namespace = Ruby::Signature::Namespace
+  Vendorer = Ruby::Signature::Vendorer
+
+  def mktmpdir
+    Dir.mktmpdir do |path|
+      yield Pathname(path)
+    end
+  end
+
+  def test_vendor_stdlib
+    mktmpdir do |path|
+      vendor_dir = path + "vendor"
+      vendorer = Vendorer.new(vendor_dir: vendor_dir)
+
+      vendorer.stdlib!
+
+      assert_operator vendor_dir + "stdlib/builtin", :directory?
+      assert_operator vendor_dir + "stdlib/builtin/basic_object.rbs", :file?
+      assert_operator vendor_dir + "stdlib/set", :directory?
+      assert_operator vendor_dir + "stdlib/set/set.rbs", :file?
+    end
+  end
+
+  def test_vendor_clean
+    mktmpdir do |path|
+      vendor_dir = path + "vendor"
+      vendorer = Vendorer.new(vendor_dir: vendor_dir)
+
+      vendorer.stdlib!
+
+      assert_operator vendor_dir, :directory?
+
+      vendorer.clean!
+
+      refute_operator vendor_dir, :directory?
+    end
+  end
+
+  def test_vendor_gem
+    mktmpdir do |path|
+      vendor_dir = path + "vendor"
+      vendorer = Vendorer.new(vendor_dir: vendor_dir)
+
+      vendorer.stdlib!
+      vendorer.gem! "ruby-signature-amber", nil
+
+      assert_operator vendor_dir + "stdlib", :directory?
+      assert_operator vendor_dir + "gems/ruby-signature-amber", :directory?
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -112,7 +112,7 @@ SIG
         end
 
         loader = Ruby::Signature::EnvironmentLoader.new()
-        loader.stdlib_root = nil
+        loader.no_builtin!
         loader.add path: tmppath
 
         env = Ruby::Signature::Environment.new()


### PR DESCRIPTION
This PR is to support vendoring signatures into projects.

The vendoring allows:

1. Having the copy of standard library signatures in projects
2. Having the copy of gem signatures in projects

For 2., the `EnvironmentLoader` now accepts `gem_vendor_path`. `EnvironmentLoader` has three attributes `stdlib_root`, `gem_vendor_path`, and `no_builtin?`. We can use the three attributes to control:

1. How standard library signatures can be found?
2. Whether gem signatures are vendored or not?
3. If we load the builtin signatures?

We also add a CLI command `rbs vendor`, which can be used to vendor the signatures. 