### PR TITLE
Fix failing stdlib_test with Ruby 3 keyword argument

### DIFF
--- a/lib/ruby/signature/test/hook.rb
+++ b/lib/ruby/signature/test/hook.rb
@@ -289,7 +289,7 @@ module Ruby
             end
 
             result
-          end
+          end.ruby2_keywords
         end
 
         def verify(instance_method: nil, singleton_method: nil, types:)

--- a/test/ruby/signature/test_test.rb
+++ b/test/ruby/signature/test_test.rb
@@ -3,6 +3,8 @@ require "test_helper"
 require "ruby/signature/test"
 require "logger"
 
+return unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
+
 class Ruby::Signature::TestTest < Minitest::Test
   include TestHelper
 


### PR DESCRIPTION
Today removing Ruby 2 keyword argument was committed to the master branch of Ruby.
https://github.com/ruby/ruby/commit/beae6cbf0fd8b6619e5212552de98022d4c4d4d4

So the stdlib test fails with the master branch.


This pull request fixes the failing.


The original idea is from @mame. Thanks!