### PR TITLE
Remove or rename duplicated test cases

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,13 @@ AllCops:
   TargetRubyVersion: 2.6
   DisabledByDefault: true
   Exclude:
-    - 'test/**/*_test.rb'
     - 'vendor/bundle/**/*'
 Rubycw/Rubycw:
   Enabled: true
+  Exclude:
+    - 'test/**/*_test.rb'
+
+Lint/DuplicateMethods:
+  Enabled: true
+  Include:
+    - 'test/**/*_test.rb'

--- a/test/stdlib/Class_test.rb
+++ b/test/stdlib/Class_test.rb
@@ -4,7 +4,7 @@ class ClassTest < StdlibTest
   target Class
   using hook.refinement
 
-  def test_new
+  def test_singleton_new
     Class.new()
     Class.new(Integer)
     Class.new { }
@@ -14,7 +14,7 @@ class ClassTest < StdlibTest
     Class.new.allocate
   end
 
-  def test_new
+  def test_instance_new
     Class.new.new
   end
 

--- a/test/stdlib/Complex_test.rb
+++ b/test/stdlib/Complex_test.rb
@@ -4,7 +4,7 @@ class ComplexTest < StdlibTest
   target Complex
   using hook.refinement
 
-  def test_polar
+  def test_singleton_polar
     Complex.polar(10)
     Complex.polar(3, 0)
     Complex.polar(3, Math::PI)
@@ -110,7 +110,7 @@ class ComplexTest < StdlibTest
     a.numerator
   end
 
-  def test_polar
+  def test_instance_polar
     Complex.rect(1.11, 2r).polar
     Complex.polar(1.11, 2r).polar
   end

--- a/test/stdlib/Hash_test.rb
+++ b/test/stdlib/Hash_test.rb
@@ -15,12 +15,12 @@ class HashTest < StdlibTest
   end
 
   # test_>
-  def test_less_than
+  def test_greater_than
     { a: 1 } > { a: 1, b: 2 }
   end
 
   # test_>=
-  def test_less_than_equal
+  def test_greater_than_equal
     { a: 1 } >= { a: 1, b: 2 }
   end
 
@@ -28,7 +28,7 @@ class HashTest < StdlibTest
     { a: nil }.compact
   end
 
-  def test_compact
+  def test_compact!
     { a: nil }.compact!
     { a: 1 }.compact!
   end

--- a/test/stdlib/Integer_test.rb
+++ b/test/stdlib/Integer_test.rb
@@ -137,11 +137,6 @@ class IntegerTest < StdlibTest
     3.abs2
   end
 
-  def test_digits
-    1.digits
-    1.digits(2)
-  end
-
   def test_allbits?
     1.allbits?(1)
     2.allbits?(1)

--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -303,7 +303,7 @@ class KernelTest < StdlibTest
     Float('1.4', exception: true)
   end
 
-  def test_hash
+  def test_Hash
     Hash(nil)
     Hash([])
     Hash({key: 1})
@@ -365,7 +365,7 @@ class KernelTest < StdlibTest
     autoload :FooBar, 'fname'
   end
 
-  def test_autoload
+  def test_autoload?
     autoload? 'FooBar'
     autoload? :FooBarBaz
   end


### PR DESCRIPTION
After #166, I found other duplicated test cases.
So this pull request renames or removes them.

This pull request contains #166.



By the way, this pull request also enables Lint/DuplicatedMethods cop for test files.
I think it is helpful to avoid test bugs. `ruby -w` also warns about it, but I guess it will be overlooked because the test prints many lines by default.


