### PR TITLE
Stdlib test runner requires test files explicitly

### DIFF
--- a/bin/test_runner.rb
+++ b/bin/test_runner.rb
@@ -2,12 +2,6 @@
 
 require "pathname"
 
-args = if ARGV.empty?
-         Pathname.glob("#{__dir__}/../test/stdlib/**/*_test.rb")
-       else
-         ARGV
-       end
-
-args.each do |arg|
+ARGV.each do |arg|
   load arg
 end


### PR DESCRIPTION
We delete the implicit test case loading. We are not using it since #108 because enabling all of the signature hooks at once causes a problem.

```
...
         7: from bin/test_runner.rb:12:in `load'
         6: from /Users/soutaro/src/ruby-signature/test/stdlib/Prime_test.rb:3:in `<top (required)>'
         5: from /Users/soutaro/src/ruby-signature/test/stdlib/Prime_test.rb:3:in `require'
         4: from /Users/soutaro/.rbenv/versions/2.7.0/lib/ruby/2.7.0/prime.rb:97:in `<top (required)>'
         3: from /Users/soutaro/.rbenv/versions/2.7.0/lib/ruby/2.7.0/prime.rb:102:in `<class:Prime>'
         2: from /Users/soutaro/.rbenv/versions/2.7.0/lib/ruby/2.7.0/prime.rb:102:in `include'
         1: from /Users/soutaro/.rbenv/versions/2.7.0/lib/ruby/2.7.0/singleton.rb:162:in `included'
/Users/soutaro/.rbenv/versions/2.7.0/lib/ruby/2.7.0/singleton.rb:162:in `private_class_method': undefined method `new' for class `#<Class:Prime>' (NameError)
```