### PR TITLE
Kernel#rand doesn't have to accept optional arguments

### DIFF
--- a/stdlib/builtin/kernel.rbs
+++ b/stdlib/builtin/kernel.rbs
@@ -437,9 +437,9 @@ module Kernel
   # [Random\#rand](https://ruby-doc.org/core-2.6.3/Random.html#method-i-rand)
   # .
   def rand: () -> Float
-          | (?Integer arg0) -> Integer
-          | (?::Range[Integer] arg0) -> Integer
-          | (?::Range[Float] arg0) -> Float
+          | (Integer arg0) -> Integer
+          | (::Range[Integer] arg0) -> Integer
+          | (::Range[Float] arg0) -> Float
 
   def readline: (?String arg0, ?Integer arg1) -> String
 

--- a/stdlib/builtin/random.rbs
+++ b/stdlib/builtin/random.rbs
@@ -30,8 +30,9 @@ class Random < Object
 
   def initialize: (?Integer seed) -> void
 
-  def rand: (?Integer | ::Range[Integer] max) -> Integer
-          | (?Float | ::Range[Float] max) -> Float
+  def rand: () -> Float
+          | (Integer | ::Range[Integer] max) -> Integer
+          | (Float | ::Range[Float] max) -> Float
 
   # Returns the seed value used to initialize the generator. This may be
   # used to initialize another generator with the same state at a later


### PR DESCRIPTION
... because `() -> Float` is explicitly written.

The same goes to `Random#rand`.

This makes Type Profiler confused that `rand()` may return not only a Float but also an Integer, so I hope it would be fixed.