### PR TITLE
More improvements for license

### DIFF
--- a/BSDL
+++ b/BSDL
@@ -1,0 +1,22 @@
+Copyright (C) 2019 Soutaro Matsumoto. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/ruby-signature.gemspec
+++ b/ruby-signature.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Type signature for Ruby classes.}
   spec.description   = %q{Type signature for Ruby classes.}
   spec.homepage      = "https://github.com/ruby/ruby-signature"
+  spec.licenses      = ['BSD-2-Clause', 'Ruby']
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.


### PR DESCRIPTION
#162 adds the COPYING file, but I found two problems with licenses.

First, this repository does not contain a BDSL file, but it is mentioned in the COPYING.

https://github.com/ruby/ruby-signature/blob/9449cba5ee2b66269d7e060d1fc723740a4b1cbf/COPYING#L1-L3

So I added the BSDL file. It was copied from ruby/ruby, but I modified the year and author.
https://github.com/ruby/ruby/blob/79f0ed3529c096c1182ccfeb7a4ad316455fc90e/BSDL


Second, the gemspec does not have "licenses" section. So I added it.
We can find the licenses IDs from https://spdx.org/licenses/, that is linked from https://guides.rubygems.org/specification-reference/#license=.


---


I am NOT a professional of license. I'm not sure the BSDL file's content is appropriate for this project. It means I'm not sure the file matches the mentioned license in the COPYING file.
So if someone approves this PR or suggests something, it will be helpful. 
