### PR TITLE
Remove meaningless type variables from builtin/array.rbs

### DIFF
--- a/stdlib/builtin/array.rbs
+++ b/stdlib/builtin/array.rbs
@@ -484,9 +484,9 @@ class Array[unchecked out Elem] < Object
   # ```
   def flatten: (?Integer depth) -> ::Array[untyped]
 
-  def `include?`: [U] (U arg0) -> bool
+  def `include?`: (Elem arg0) -> bool
 
-  def index: [U] (?U arg0) -> Integer?
+  def index: (Elem arg0) -> Integer?
            | () { (Elem arg0) -> untyped } -> Integer?
            | () -> ::Enumerator[Elem, self]
 
@@ -552,7 +552,7 @@ class Array[unchecked out Elem] < Object
 
   def push: (*Elem arg0) -> ::Array[Elem]
 
-  def rassoc: [U] (U arg0) -> Elem?
+  def rassoc: (Elem arg0) -> Elem?
 
   def reject: () { (Elem arg0) -> bool } -> ::Array[Elem]
             | () -> ::Enumerator[Elem, self]


### PR DESCRIPTION
Usually, the argument of `Array#include?` is considered as its element
type.  The same goes to `Array#index` and `Array#rassoc`.