### PR TITLE
Fix typo

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -20,8 +20,8 @@
     - Use `bin/annotate-with-rdoc stdlib/path/to/signature.rbs` to annotate the RBS files.
     - Committing the generated annotations is recommended.
 6. Fix method types and comments.
-    - The auto generated RDoc comments include `argslist` section, which we don't expect to be included the RBS files.
-    - Delete the `argslist` sections.
+    - The auto generated RDoc comments include `arglists` section, which we don't expect to be included the RBS files.
+    - Delete the `arglists` sections.
     - Give methods correct types.
     - Write tests, if possible. (If it is too difficult to write test, skip it.)
 
@@ -50,7 +50,7 @@ You may find the *Good for first contributor* column where you can find some cla
   * You can use --method-owner if you want to print method of other classes too, for documentation purpose.
 * `bin/annotate-with-rdoc stdlib/builtin/string.rbs`
   * Write comments using RDoc.
-  * It contains argslist section, but I don't think we should have it in RBS files.
+  * It contains arglists section, but I don't think we should have it in RBS files.
 * `bin/query-rdoc String#initialize`
   * Print RDoc documents in the format you can copy-and-paste to RBS.
 * `bin/sort stdlib/builtin/string.rbs`


### PR DESCRIPTION
correct `argslist` to `arglists`

↓ documentations created by `bin/annotate-with-rdoc` command
<img width="545" alt="screenshot" src="https://user-images.githubusercontent.com/25678257/74400040-20a91400-4e60-11ea-858c-7e4b014cbfef.png">
