### PR TITLE
Fix --no-stdlib option

### DIFF
--- a/lib/ruby/signature/cli.rb
+++ b/lib/ruby/signature/cli.rb
@@ -23,7 +23,7 @@ module Ruby
             loader.add(path: Pathname(dir))
           end
 
-          loader.no_builtin! nil if no_stdlib
+          loader.no_builtin! if no_stdlib
 
           loader
         end

--- a/test/ruby/signature/cli_test.rb
+++ b/test/ruby/signature/cli_test.rb
@@ -30,6 +30,14 @@ class Ruby::Signature::CliTest < Minitest::Test
     end
   end
 
+  def test_no_stdlib_option
+    with_cli do |cli|
+      cli.run(%w(--no-stdlib ast))
+
+      assert_equal '[]', stdout.string
+    end
+  end
+
   def test_list
     with_cli do |cli|
       cli.run(%w(-r pathname list))


### PR DESCRIPTION
This pull request enables to work `--no-stdlib` option for CLI.

# Reproduce

```bash
$ RUBYLIB=lib/ ./exe/rbs --no-stdlib ast 
/home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/environment_loader.rb:109:in `no_builtin!': wrong number of arguments (given 1, expected 0) (ArgumentError)
	from /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/cli.rb:26:in `setup'
	from /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/cli.rb:95:in `run_ast'
	from /home/pocke/ghq/github.com/ruby/ruby-signature/lib/ruby/signature/cli.rb:86:in `run'
	from /home/pocke/ghq/github.com/ruby/ruby-signature/exe/ruby-signature:7:in `<top (required)>'
	from ./exe/rbs:3:in `load'
	from ./exe/rbs:3:in `<main>'
```

It will be fixed by this pull request like the following:

```bash
$ RUBYLIB=lib/ ./exe/rbs --no-stdlib ast 
[]
```