### PR TITLE
Add `rbs parse` subcommand

### DIFF
--- a/lib/ruby/signature/cli.rb
+++ b/lib/ruby/signature/cli.rb
@@ -37,7 +37,7 @@ module Ruby
         @stderr = stderr
       end
 
-      COMMANDS = [:ast, :list, :ancestors, :methods, :method, :validate, :constant, :paths, :prototype, :vendor, :version, :check]
+      COMMANDS = [:ast, :list, :ancestors, :methods, :method, :validate, :constant, :paths, :prototype, :vendor, :version, :parse]
 
       def library_parse(opts, options:)
         opts.on("-r LIBRARY") do |lib|
@@ -523,7 +523,7 @@ module Ruby
         end
       end
 
-      def run_check(args, options)
+      def run_parse(args, options)
         loader = EnvironmentLoader.new()
 
         syntax_error = false

--- a/lib/ruby/signature/parser.y
+++ b/lib/ruby/signature/parser.y
@@ -1330,11 +1330,12 @@ class SyntaxError < StandardError
 end
 
 class SemanticsError < StandardError
-  attr_reader :subject
+  attr_reader :subject, :location, :original_message
 
   def initialize(message, subject:, location:)
     @subject = subject
     @location = location
+    @original_message = message
 
     super "parse error on #{location}: #{message}"
   end

--- a/test/ruby/signature/cli_test.rb
+++ b/test/ruby/signature/cli_test.rb
@@ -165,7 +165,7 @@ singleton(::BasicObject)
     end
   end
 
-  def test_check
+  def test_parse
     Dir.mktmpdir do |dir|
       dir = Pathname(dir)
       dir.join('syntax_error.rbs').write(<<~RBS)
@@ -185,7 +185,7 @@ singleton(::BasicObject)
       RBS
 
       with_cli do |cli|
-        assert_raises(SystemExit) { cli.run(%W(check #{dir})) }
+        assert_raises(SystemExit) { cli.run(%W(parse #{dir})) }
 
         assert_equal [
           "#{dir}/semantics_error.rbs:2:2: Interface cannot have singleton method",


### PR DESCRIPTION
This pull request will adds `rbs check` sub-command to check syntax error from .rbs files.

For example:

```bash
$ cat test.rbs
class C
  def foo: () ->
end

$ rbs check test.rbs
test.rbs:3:0: parse error on value: (kEND)
```