### PR TITLE
Fix overlooked `private def foo` style method definitions

### DIFF
--- a/lib/ruby/signature/prototype/rb.rb
+++ b/lib/ruby/signature/prototype/rb.rb
@@ -210,6 +210,9 @@ module Ruby
                 end
               end
             end
+            each_child node do |child|
+              process child, namespace: namespace, current_module: current_module, comments: comments, singleton: singleton
+            end
 
           when :CDECL
             type_name = case

--- a/test/ruby/signature/rb_prototype_test.rb
+++ b/test/ruby/signature/rb_prototype_test.rb
@@ -277,4 +277,23 @@ class C
 end
     EOF
   end
+
+  def test_method_definition_in_fcall
+    parser = RB.new
+
+    rb = <<-'EOR'
+class C
+  private def foo
+  end
+end
+    EOR
+
+    parser.parse(rb)
+
+    assert_write parser.decls, <<-EOF
+class C
+  def foo: () -> untyped
+end
+    EOF
+  end
 end


### PR DESCRIPTION
# Problem


Currently `rbs prototype rb` command ignores `private def foo` style method definition.

```ruby
class C
  private def foo() end
end
```

```bash
$ RUBYLIB=lib ./exe/rbs prototype rb test.rb 
class C
end
```


Because the prototype generator handles `FCALL` node and the method definition in `private def foo() end` is a child of the FCALL node.
But it ignores FCALL's children, so the method definition is ignored.


# Solution



Handle children of FCALL node.



Note that the implementation just ignores the visibility of methods. Generated `.rbs` files don't contain `private` keyword.
I think it is not a matter of this pull request.