### PR TITLE
Make `rbs prototype rb` to be aware of returned type

### DIFF
--- a/lib/ruby/signature/builtin_names.rb
+++ b/lib/ruby/signature/builtin_names.rb
@@ -49,6 +49,9 @@ module Ruby
       Symbol = Name.define(:Symbol)
       Integer = Name.define(:Integer)
       Float = Name.define(:Float)
+      Regexp = Name.define(:Regexp)
+      TrueClass = Name.define(:TrueClass)
+      FalseClass = Name.define(:FalseClass)
     end
   end
 end

--- a/lib/ruby/signature/prototype/rb.rb
+++ b/lib/ruby/signature/prototype/rb.rb
@@ -339,12 +339,12 @@ module Ruby
             if lit.match?(/\A[ -~]+\z/)
               Types::Literal.new(literal: lit, location: nil)
             else
-              Types::ClassInstance.new(name: '::String', args: [], location: nil)
+              BuiltinNames::String.instance_type
             end
           when :DSTR, :XSTR
-            Types::ClassInstance.new(name: '::String', args: [], location: nil)
+            BuiltinNames::String.instance_type
           when :DSYM
-            Types::ClassInstance.new(name: '::Symbol', args: [], location: nil)
+            BuiltinNames::Symbol.instance_type
           when :DREGX
             Types::ClassInstance.new(name: '::Regexp', args: [], location: nil)
           when :TRUE
@@ -361,7 +361,7 @@ module Ruby
               if lit.match?(/\A[ -~]+\z/)
                 Types::Literal.new(literal: lit, location: nil)
               else
-                Types::ClassInstance.new(name: "::#{name}", args: [], location: nil)
+                BuiltinNames::Symbol.instance_type
               end
             when Integer
               Types::Literal.new(literal: lit, location: nil)
@@ -369,15 +369,15 @@ module Ruby
               Types::ClassInstance.new(name: "::#{name}", args: [], location: nil)
             end
           when :ZLIST, :ZARRAY
-            Types::ClassInstance.new(name: "::Array", args: [untyped], location: nil)
+            BuiltinNames::Array.instance_type([untyped])
           when :LIST, :ARRAY
             elem_types = node.children.compact.map { |e| literal_to_type(e) }
             t = types_to_union_type(elem_types)
-            Types::ClassInstance.new(name: "::Array", args: [t], location: nil)
+            BuiltinNames::Array.instance_type([t])
           when :DOT2, :DOT3
             types = node.children.map { |c| literal_to_type(c) }.reject { }
             type = range_element_type(types)
-            Types::ClassInstance.new(name: '::Range', args: [type], location: nil)
+            BuiltinNames::Range.instance_type([type])
           when :HASH
             list = node.children[0]
             if list
@@ -399,7 +399,7 @@ module Ruby
             else
               key_type = types_to_union_type(key_types)
               value_type = types_to_union_type(value_types)
-              Types::ClassInstance.new(name: "::Hash", args: [key_type, value_type], location: nil)
+              BuiltinNames::Hash.instance_type([key_type, value_type])
             end
           else
             untyped

--- a/lib/ruby/signature/types.rb
+++ b/lib/ruby/signature/types.rb
@@ -383,8 +383,14 @@ module Ruby
         end
 
         def to_s(level = 0)
+          return "{ }" if self.fields.empty?
+
           fields = self.fields.map do |key, type|
-            "#{key}: #{type}"
+            if key.is_a?(Symbol) && key.match?(/\A[A-Za-z_][A-Za-z_]*\z/) && !key.match?(Parser::KEYWORDS_RE)
+              "#{key}: #{type}"
+            else
+              "#{key.inspect} => #{type}"
+            end
           end
           "{ #{fields.join(", ")} }"
         end

--- a/test/ruby/signature/rb_prototype_test.rb
+++ b/test/ruby/signature/rb_prototype_test.rb
@@ -56,11 +56,108 @@ end
 
     assert_write parser.decls, <<-EOF
 class Hello
-  def hello: (untyped a, ?::Integer b, *untyped c, untyped d, e: untyped e, ?f: ::Integer f, **untyped g) { () -> untyped } -> untyped
+  def hello: (untyped a, ?::Integer b, *untyped c, untyped d, e: untyped e, ?f: ::Integer f, **untyped g) { () -> untyped } -> nil
 
   def self.world: () { (untyped, untyped, untyped, x: untyped, y: untyped) -> untyped } -> untyped
 
-  def kw_req: (a: untyped a) -> untyped
+  def kw_req: (a: untyped a) -> nil
+end
+    EOF
+  end
+
+  def test_defs_return_type
+    parser = RB.new
+
+    rb = <<-'EOR'
+class Hello
+  def str() "foo\nbar" end
+  def str_lit() "foo" end
+  def dstr() "f#{x}oo" end
+  def xstr() `ls` end
+
+  def sym() :foo end
+  def dsym() :"foo#{bar}" end
+
+  def regx() /foo/ end
+  def dregx() /foo#{bar}/ end
+
+  def t() true end
+  def f() false end
+  def n() nil end
+  def n2() end
+
+  def int() 42 end
+  def float() 4.2 end
+  def complex() 42i end
+  def rational() 42r end
+
+  def zlist() [] end
+  def list1() [1, '2', :x] end
+  def list2() [1, 2, foo] end
+
+  def range1() 1..foo end
+  def range2() 1..42 end
+  def range3() foo..bar end
+
+  def hash1() {} end
+  def hash2() { foo: 1 } end
+  def hash3() { foo: { bar: 42 }, x: { y: z } } end
+end
+    EOR
+
+    parser.parse(rb)
+
+    assert_write parser.decls, <<-EOF
+class Hello
+  def str: () -> ::String
+
+  def str_lit: () -> "foo"
+
+  def dstr: () -> ::String
+
+  def xstr: () -> ::String
+
+  def sym: () -> :foo
+
+  def dsym: () -> ::Symbol
+
+  def regx: () -> ::Regexp
+
+  def dregx: () -> ::Regexp
+
+  def t: () -> ::TrueClass
+
+  def f: () -> ::FalseClass
+
+  def n: () -> nil
+
+  def n2: () -> nil
+
+  def int: () -> 42
+
+  def float: () -> ::Float
+
+  def complex: () -> ::Complex
+
+  def rational: () -> ::Rational
+
+  def zlist: () -> ::Array[untyped]
+
+  def list1: () -> ::Array[1 | "2" | :x]
+
+  def list2: () -> ::Array[untyped]
+
+  def range1: () -> ::Range[::Integer]
+
+  def range2: () -> ::Range[::Integer]
+
+  def range3: () -> ::Range[untyped]
+
+  def hash1: () -> { }
+
+  def hash2: () -> { foo: 1 }
+
+  def hash3: () -> { foo: { bar: 42 }, x: { y: untyped } }
 end
     EOF
   end
@@ -80,7 +177,7 @@ end
 
     assert_write parser.decls, <<-EOF
 class Hello
-  def self.hello: () -> untyped
+  def self.hello: () -> nil
 end
     EOF
   end
@@ -165,10 +262,10 @@ class Hello
   extend ::Bar
 
   # Comment for hello
-  def hello: () -> untyped
+  def hello: () -> nil
 
   # Comment for world
-  def self.world: () -> untyped
+  def self.world: () -> nil
 
   # Comment for attr_reader
   attr_reader x: untyped
@@ -197,7 +294,7 @@ end
 
     assert_write parser.decls, <<-EOF
 extension Object (Toplevel)
-  def hello: () -> untyped
+  def hello: () -> nil
 end
     EOF
   end

--- a/test/ruby/signature/rb_prototype_test.rb
+++ b/test/ruby/signature/rb_prototype_test.rb
@@ -389,7 +389,7 @@ end
 
     assert_write parser.decls, <<-EOF
 class C
-  def foo: () -> untyped
+  def foo: () -> nil
 end
     EOF
   end

--- a/test/ruby/signature/types_test.rb
+++ b/test/ruby/signature/types_test.rb
@@ -12,6 +12,11 @@ class Ruby::Signature::TypesTest < Minitest::Test
     assert_equal ":foo ?", parse_type(":foo ?").to_s
     assert_equal "[ Integer, bool? ]", parse_type("[Integer, bool?]").to_s
     assert_equal "[ ]", parse_type("[   ]").to_s
+    assert_equal "{ }", Types::Record.new(fields: {}, location: nil).to_s # NOTE: parse_type("{ }") is syntax error
+    assert_equal "{ a: 1 }", parse_type("{ a: 1 }").to_s
+    assert_equal "{ :+ => 1 }", parse_type("{ :+ => 1 }").to_s
+    assert_equal '{ a: 1, 1 => 42, "foo" => untyped }', parse_type("{ a: 1, 1 => 42, 'foo' => untyped }").to_s
+    assert_equal '{ :type => untyped }', parse_type("{ :type => untyped }").to_s
     assert_equal "String | bool?", parse_type("String | bool?").to_s
     assert_equal "(String | bool)?", parse_type("(String | bool)?").to_s
     assert_equal "String & bool?", parse_type("String & bool?").to_s


### PR DESCRIPTION

`rbs prototype rb` command generates prototypes of method type definitions, but the returned types are always `untyped`.
It can decide the returned type easily if the method only contains a literal. Like `def foo() [1,2,3] end` or `def foo() {foo: 1} end`.


And I think it is useful in some cases.
I tried using this patch in our Rails application, and I found many meaningful changes.
Especially I think typing for a method that returns a Hash is useful. 
I also tried using it RuboCop's code. The result is here: https://gist.github.com/pocke/6fa639fc7549c90a852da769cbcd65b1



Note that the patch also includes Record type serializer bug fixes.