### PR TITLE
Fix `String#encode`'s fallback option, it should accept an object which has `[]` method

### DIFF
--- a/stdlib/builtin/string.rbs
+++ b/stdlib/builtin/string.rbs
@@ -754,14 +754,14 @@ class String
   # :   Replaces CRLF ("r\n") and CR ("r") with LF ("n") if value is true.
   #
   #
-  def encode: (?Encoding | string encoding, ?Encoding | string from_encoding, ?invalid: :replace ?, ?undef: :replace ?, ?replace: String, ?fallback: Hash[String, String] | Proc | Method, ?xml: :text | :attr, ?universal_newline: true, ?cr_newline: true, ?crlf_newline: true) -> String
+  def encode: (?Encoding | string encoding, ?Encoding | string from_encoding, ?invalid: :replace ?, ?undef: :replace ?, ?replace: String, ?fallback: String::encode_fallback, ?xml: :text | :attr, ?universal_newline: true, ?cr_newline: true, ?crlf_newline: true) -> String
 
   # The first form transcodes the contents of *str* from str.encoding to
   # `encoding`. The second form transcodes the contents of *str* from src_encoding
   # to dst_encoding. The options Hash gives details for conversion. See
   # String#encode for details. Returns the string even if no changes were made.
   #
-  def encode!: (?Encoding | string encoding, ?Encoding | string from_encoding, ?invalid: :replace ?, ?undef: :replace ?, ?replace: String, ?fallback: Hash[String, String] | Proc | Method, ?xml: :text | :attr, ?universal_newline: true, ?cr_newline: true, ?crlf_newline: true) -> self
+  def encode!: (?Encoding | string encoding, ?Encoding | string from_encoding, ?invalid: :replace ?, ?undef: :replace ?, ?replace: String, ?fallback: String::encode_fallback, ?xml: :text | :attr, ?universal_newline: true, ?cr_newline: true, ?crlf_newline: true) -> self
 
   # Returns the Encoding object that represents the encoding of obj.
   #
@@ -1892,3 +1892,9 @@ class String
   #
   alias initialize_copy replace
 end
+
+interface _ArefFromStringToString
+  def []: (String) -> String
+end
+
+type String::encode_fallback = Hash[String, String] | Proc | Method | _ArefFromStringToString

--- a/test/stdlib/String_test.rb
+++ b/test/stdlib/String_test.rb
@@ -626,6 +626,8 @@ class StringInstanceTest < Minitest::Test
                      "string", :encode, fallback: proc { |s| s }
     assert_send_type "(fallback: Method) -> String",
                      "string", :encode, fallback: "test".method(:+)
+    assert_send_type "(fallback: ArefFromStringToString) -> String",
+                     "string", :encode, fallback: ArefFromStringToString.new
     assert_send_type "(cr_newline: true) -> String",
                      "string", :encode, cr_newline: true
     assert_send_type "(crlf_newline: true) -> String",
@@ -659,6 +661,8 @@ class StringInstanceTest < Minitest::Test
                      "string", :encode!, fallback: proc { |s| s }
     assert_send_type "(fallback: Method) -> self",
                      "string", :encode!, fallback: "test".method(:+)
+    assert_send_type "(fallback: ArefFromStringToString) -> String",
+                     "string", :encode, fallback: ArefFromStringToString.new
     assert_send_type "(cr_newline: true) -> self",
                      "string", :encode!, cr_newline: true
     assert_send_type "(crlf_newline: true) -> self",

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -57,6 +57,12 @@ class Enum
   end
 end
 
+class ArefFromStringToString
+  def [](str)
+    "!"
+  end
+end
+
 class StdlibTest < Minitest::Test
 
   DEFAULT_LOGGER = Logger.new(STDERR)


### PR DESCRIPTION
# Problem


`String#encode` accepts an object which has `[]` method as a fallback, but the type definition does not accept it.


# Solution

Update the type of `fallback` option to accept it.
And I'd like to use the type for `Pathname#binwrite` because it accepts keyword arguments of `String#encode`. So I expose `String::encode_fallback` as a type alias.



# Note

Note that actually an object with `[]` method does not work as a fallback in Ruby 2.7.0.
I reported the problem to bugs.ruby-lang.org, and it has been fixed.
https://bugs.ruby-lang.org/issues/16649


I concerned the stdlib test raises an error, but it works well. Because the fallback option is passed but it is not used.