### PR TITLE
Add conversion of T.attached_class for prototype rbi

### DIFF
--- a/lib/ruby/signature/prototype/rbi.rb
+++ b/lib/ruby/signature/prototype/rbi.rb
@@ -460,6 +460,8 @@ module Ruby
             Types::Optional.new(type: type, location: nil)
           when call_node?(type_node, name: :self_type)
             Types::Bases::Self.new(location: nil)
+          when call_node?(type_node, name: :attached_class)
+            Types::Bases::Instance.new(location: nil)
           when call_node?(type_node, name: :noreturn)
             Types::Bases::Bottom.new(location: nil)
           when call_node?(type_node, name: :class_of)

--- a/test/ruby/signature/rbi_prototype_test.rb
+++ b/test/ruby/signature/rbi_prototype_test.rb
@@ -247,6 +247,40 @@ end
     EOF
   end
 
+  def test_self_type
+    parser = RBI.new
+
+    parser.parse(<<-EOF)
+class File
+  sig { returns(T.self_type) }
+  def self.split; end
+end
+    EOF
+
+    assert_write parser.decls, <<-EOF
+class File
+  def self.split: () -> self
+end
+    EOF
+  end
+
+  def test_attached_class
+    parser = RBI.new
+
+    parser.parse(<<-EOF)
+class File
+  sig { returns(T.attached_class) }
+  def self.split; end
+end
+    EOF
+
+    assert_write parser.decls, <<-EOF
+class File
+  def self.split: () -> instance
+end
+    EOF
+  end
+
   def test_noreturn
     parser = RBI.new
 


### PR DESCRIPTION
This converts [T.attached_class](https://sorbet.org/docs/attached-class) to its equivalent in RBS, which is `instance`. 

Also adds a test for it, plus a test for converting `T.self_type` since there wasn't one already.