### PR TITLE
Handle untyped blocks when converting RBIs.

### DIFF
--- a/lib/ruby/signature/prototype/rbi.rb
+++ b/lib/ruby/signature/prototype/rbi.rb
@@ -389,6 +389,11 @@ module Ruby
             if (type = vars[block])
               if type.is_a?(Types::Proc)
                 method_block = MethodType::Block.new(required: true, type: type.type)
+              elsif type.is_a?(Types::Bases::Any)
+                method_block = MethodType::Block.new(
+                  required: true,
+                  type: Types::Function.empty(Types::Bases::Any.new(location: nil))
+                )
               else
                 STDERR.puts "Unexpected block type: #{type}"
                 PP.pp args_node, STDERR

--- a/test/ruby/signature/rbi_prototype_test.rb
+++ b/test/ruby/signature/rbi_prototype_test.rb
@@ -169,7 +169,7 @@ end
     parser.parse(<<-EOF)
 class File
   sig { params(blk: T.untyped).void }
-  def self.split; end
+  def self.split(&blk); end
 end
     EOF
 

--- a/test/ruby/signature/rbi_prototype_test.rb
+++ b/test/ruby/signature/rbi_prototype_test.rb
@@ -163,6 +163,23 @@ end
     EOF
   end
 
+  def test_untyped_block
+    parser = RBI.new
+
+    parser.parse(<<-EOF)
+class File
+  sig { params(blk: T.untyped).void }
+  def self.split; end
+end
+    EOF
+
+    assert_write parser.decls, <<-EOF
+class File
+  def self.split: () { () -> untyped } -> void
+end
+    EOF
+  end
+
   def test_overloading
     parser = RBI.new
 


### PR DESCRIPTION
Resolves #215.

Previously when converting an RBI file with a block parameter that was untyped, you'd get a warning about an unexpected block type if it was set to `T.untyped`:

```
Unexpected block type: untyped
(SCOPE@4:2-4:20
 tbl: [:blk]
 args:
   (ARGS@4:10-4:14
    pre_num: 0
    pre_init: nil
    opt: nil
    first_post: nil
    post_num: 0
    post_init: nil
    rest: nil
    kw: nil
    kwrest: nil
    block: :blk)
 body: nil)
```

This PR fixes that.

Input:

```ruby
# typed: true
class Foo
  sig { params(blk: T.untyped).returns(T.untyped) }
  def self.bar(&blk); end
end
```

Output:

```
# typed: true
class Foo
  def self.bar: () { () -> untyped } -> untyped
end
```

It no longer errors :)