### PR TITLE
Handle optional blocks in the RBI parser

### DIFF
--- a/lib/ruby/signature/prototype/rbi.rb
+++ b/lib/ruby/signature/prototype/rbi.rb
@@ -394,6 +394,9 @@ module Ruby
                   required: true,
                   type: Types::Function.empty(Types::Bases::Any.new(location: nil))
                 )
+              # Handle an optional block like `T.nilable(T.proc.void)`.
+              elsif type.is_a?(Types::Optional) && type.type.is_a?(Types::Proc)
+                method_block = MethodType::Block.new(required: false, type: type.type.type)
               else
                 STDERR.puts "Unexpected block type: #{type}"
                 PP.pp args_node, STDERR

--- a/test/ruby/signature/rbi_prototype_test.rb
+++ b/test/ruby/signature/rbi_prototype_test.rb
@@ -180,6 +180,23 @@ end
     EOF
   end
 
+  def test_optional_block
+    parser = RBI.new
+
+    parser.parse(<<-EOF)
+class File
+  sig { params(blk: T.nilable(T.proc.void)).void }
+  def self.split(&blk); end
+end
+    EOF
+
+    assert_write parser.decls, <<-EOF
+class File
+  def self.split: () ?{ () -> void } -> void
+end
+    EOF
+  end
+
   def test_overloading
     parser = RBI.new
 


### PR DESCRIPTION
Fixes #214.

Optional blocks (`T.nilable(T.proc.void)`) weren't being handled correctly by the RBI parser, and would output an error and fallback to an untyped block rather than returning the correct RBS syntax. With this change it's now handled correctly.

Input:

```ruby
# typed: true
class Foo
  sig { params(blk: T.nilable(T.proc.void)).returns(T.untyped) }
  def self.bar(&blk); end
end
```

Output:

```
# typed: true
class Foo
  def self.bar: () ?{ () -> void } -> untyped
end
```