### PR TITLE
Revise `Dir.open` type

### DIFF
--- a/stdlib/builtin/dir.rbs
+++ b/stdlib/builtin/dir.rbs
@@ -256,7 +256,7 @@ class Dir
   #     Dir.open( string, encoding: enc ) {| aDir | block } -> anObject
   #
   def self.open: (string, ?encoding: Encoding | string | nil) -> Dir
-               | [U] (string, ?encoding: Encoding) { (Dir) -> U } -> U
+               | [U] (string, ?encoding: Encoding | string | nil) { (Dir) -> U } -> U
 
   # Returns the path to the current working directory of this process as a string.
   #

--- a/test/stdlib/Dir_test.rb
+++ b/test/stdlib/Dir_test.rb
@@ -143,10 +143,14 @@ class DirSingletonTest < Minitest::Test
   def test_open
     assert_send_type "(::String) -> ::Dir",
                      Dir, :open, "."
+    assert_send_type "(::String, encoding: String) -> ::Dir",
+                     Dir, :open, ".", encoding: 'UTF-8'
     assert_send_type "(::ToStr, encoding: Encoding) -> ::Dir",
                      Dir, :open, ToStr.new("."), encoding: Encoding::UTF_8
     assert_send_type "(::ToStr) { (::Dir) -> 31 } -> 31",
                      Dir, :open, ToStr.new(".") do 31 end
+    assert_send_type "(::String, encoding: String) { (::Dir) -> 31 } -> 31",
+                     Dir, :open, ".", encoding: 'UTF-8' do 31 end
   end
 
   def test_pwd


### PR DESCRIPTION
`Dir.open` with block accepts `encoding: Encoding | string | nil`, but the type definition only accepted `encoding: Encoding`.