### PR TITLE
Add docs to base64.rbs and simplify the signatures

### DIFF
--- a/stdlib/base64/base64.rbs
+++ b/stdlib/base64/base64.rbs
@@ -1,15 +1,8 @@
 module Base64
-  def self.decode64: (String str) -> String
-  def self.encode64: (String bin) -> String
-  def self.strict_decode64: (String str) -> String
-  def self.strict_encode64: (String bin) -> String
-  def self.urlsafe_decode64: (String str) -> String
-  def self.urlsafe_encode64: (String bin) -> String
-
-  def decode64: (String str) -> String
-  def encode64: (String bin) -> String
-  def strict_decode64: (String str) -> String
-  def strict_encode64: (String bin) -> String
-  def urlsafe_decode64: (String str) -> String
-  def urlsafe_encode64: (String bin, ?padding: bool) -> String
+  def self?.decode64: (String str) -> String
+  def self?.encode64: (String bin) -> String
+  def self?.strict_decode64: (String str) -> String
+  def self?.strict_encode64: (String bin) -> String
+  def self?.urlsafe_decode64: (String str) -> String
+  def self?.urlsafe_encode64: (String bin, ?padding: bool) -> String
 end

--- a/stdlib/base64/base64.rbs
+++ b/stdlib/base64/base64.rbs
@@ -1,8 +1,71 @@
+# The Base64 module provides for the encoding (#encode64, #strict_encode64,
+# #urlsafe_encode64) and decoding (#decode64, #strict_decode64,
+# #urlsafe_decode64) of binary data using a Base64 representation.
+#
+# ## Example
+#
+# A simple encoding and decoding.
+#
+#     require "base64"
+#
+#     enc   = Base64.encode64('Send reinforcements')
+#                         # -> "U2VuZCByZWluZm9yY2VtZW50cw==\n"
+#     plain = Base64.decode64(enc)
+#                         # -> "Send reinforcements"
+#
+# The purpose of using base64 to encode data is that it translates any binary
+# data into purely printable characters.
+#
 module Base64
+  # Returns the Base64-decoded version of `str`. This method complies with RFC
+  # 2045. Characters outside the base alphabet are ignored.
+  #
+  #     require 'base64'
+  #     str = 'VGhpcyBpcyBsaW5lIG9uZQpUaGlzIG' +
+  #           'lzIGxpbmUgdHdvClRoaXMgaXMgbGlu' +
+  #           'ZSB0aHJlZQpBbmQgc28gb24uLi4K'
+  #     puts Base64.decode64(str)
+  #
+  # *Generates:*
+  #
+  #     This is line one
+  #     This is line two
+  #     This is line three
+  #     And so on...
   def self?.decode64: (String str) -> String
+
+  # Returns the Base64-encoded version of `bin`. This method complies with RFC
+  # 2045. Line feeds are added to every 60 encoded characters.
+  #
+  #     require 'base64'
+  #     Base64.encode64("Now is the time for all good coders\nto learn Ruby")
+  #
+  # *Generates:*
+  #
+  #     Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4g
+  #     UnVieQ==
   def self?.encode64: (String bin) -> String
+
+  # Returns the Base64-decoded version of `str`. This method complies with RFC
+  # 4648. ArgumentError is raised if `str` is incorrectly padded or contains
+  # non-alphabet characters.  Note that CR or LF are also rejected.
   def self?.strict_decode64: (String str) -> String
+
+  # Returns the Base64-encoded version of `bin`. This method complies with RFC
+  # 4648. No line feeds are added.
   def self?.strict_encode64: (String bin) -> String
+
+  # Returns the Base64-decoded version of `str`. This method complies with ``Base
+  # 64 Encoding with URL and Filename Safe Alphabet'' in RFC 4648. The alphabet
+  # uses '-' instead of '+' and '_' instead of '/'.
+  #
+  # The padding character is optional. This method accepts both correctly-padded
+  # and unpadded input. Note that it still rejects incorrectly-padded input.
   def self?.urlsafe_decode64: (String str) -> String
+
+  # Returns the Base64-encoded version of `bin`. This method complies with ``Base
+  # 64 Encoding with URL and Filename Safe Alphabet'' in RFC 4648. The alphabet
+  # uses '-' instead of '+' and '_' instead of '/'. Note that the result can still
+  # contain '='. You can remove the padding by setting `padding` as false.
   def self?.urlsafe_encode64: (String bin, ?padding: bool) -> String
 end


### PR DESCRIPTION
They were module functions (both instance and class methods), so I de-duplicated them using the `self?.method_name` syntax.