### PR TITLE
Add docs for random.rbs

### DIFF
--- a/stdlib/builtin/random.rbs
+++ b/stdlib/builtin/random.rbs
@@ -1,74 +1,187 @@
-# [Random](Random) provides an interface to Ruby's
-# pseudo-random number generator, or PRNG. The PRNG produces a
-# deterministic sequence of bits which approximate true randomness. The
-# sequence may be represented by integers, floats, or binary strings.
-# 
+# Random provides an interface to Ruby's pseudo-random number generator, or
+# PRNG.  The PRNG produces a deterministic sequence of bits which approximate
+# true randomness. The sequence may be represented by integers, floats, or
+# binary strings.
+#
 # The generator may be initialized with either a system-generated or
-# user-supplied seed value by using
-# [::srand](Random#method-c-srand).
-# 
-# The class method [\#rand](Random#method-i-rand)
-# provides the base functionality of
-# [Kernel\#rand](https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-rand)
-# along with better handling of floating point values. These are both
-# interfaces to Random::DEFAULT, the Ruby system PRNG.
-# 
-# [::new](Random#method-c-new) will create a new PRNG
-# with a state independent of Random::DEFAULT, allowing multiple
-# generators with different seed values or sequence positions to exist
-# simultaneously. [Random](Random) objects can be
-# marshaled, allowing sequences to be saved and resumed.
-# 
-# PRNGs are currently implemented as a modified Mersenne Twister with a
-# period of 2\*\*19937-1.
+# user-supplied seed value by using Random.srand.
+#
+# The class method Random.rand provides the base functionality of Kernel.rand
+# along with better handling of floating point values. These are both interfaces
+# to Random::DEFAULT, the Ruby system PRNG.
+#
+# Random.new will create a new PRNG with a state independent of Random::DEFAULT,
+# allowing multiple generators with different seed values or sequence positions
+# to exist simultaneously. Random objects can be marshaled, allowing sequences
+# to be saved and resumed.
+#
+# PRNGs are currently implemented as a modified Mersenne Twister with a period
+# of 2**19937-1.
+#
 class Random < Object
   include Random::Formatter
 
+  # Returns true if the two generators have the same internal state, otherwise
+  # false.  Equivalent generators will return the same sequence of pseudo-random
+  # numbers.  Two generators will generally have the same state only if they were
+  # initialized with the same seed
+  #
+  #     Random.new == Random.new             # => false
+  #     Random.new(1234) == Random.new(1234) # => true
+  #
+  # and have the same invocation history.
+  #
+  #     prng1 = Random.new(1234)
+  #     prng2 = Random.new(1234)
+  #     prng1 == prng2 # => true
+  #
+  #     prng1.rand     # => 0.1915194503788923
+  #     prng1 == prng2 # => false
+  #
+  #     prng2.rand     # => 0.1915194503788923
+  #     prng1 == prng2 # => true
+  #
   def ==: (untyped arg0) -> bool
 
+  # Returns a random binary string containing `size` bytes.
+  #
+  #     random_string = Random.new.bytes(10) # => "\xD7:R\xAB?\x83\xCE\xFAkO"
+  #     random_string.size                   # => 10
+  #
   def bytes: (Integer size) -> String
 
+  # Creates a new PRNG using `seed` to set the initial state. If `seed` is
+  # omitted, the generator is initialized with Random.new_seed.
+  #
+  # See Random.srand for more information on the use of seed values.
+  #
   def initialize: (?Integer seed) -> void
 
+  # When `max` is an Integer, `rand` returns a random integer greater than or
+  # equal to zero and less than `max`. Unlike Kernel.rand, when `max` is a
+  # negative integer or zero, `rand` raises an ArgumentError.
+  #
+  #     prng = Random.new
+  #     prng.rand(100)       # => 42
+  #
+  # When `max` is a Float, `rand` returns a random floating point number between
+  # 0.0 and `max`, including 0.0 and excluding `max`.
+  #
+  #     prng.rand(1.5)       # => 1.4600282860034115
+  #
+  # When `max` is a Range, `rand` returns a random number where
+  # range.member?(number) == true.
+  #
+  #     prng.rand(5..9)      # => one of [5, 6, 7, 8, 9]
+  #     prng.rand(5...9)     # => one of [5, 6, 7, 8]
+  #     prng.rand(5.0..9.0)  # => between 5.0 and 9.0, including 9.0
+  #     prng.rand(5.0...9.0) # => between 5.0 and 9.0, excluding 9.0
+  #
+  # Both the beginning and ending values of the range must respond to subtract
+  # (`-`) and add (`+`)methods, or rand will raise an ArgumentError.
+  #
   def rand: () -> Float
           | (Integer | ::Range[Integer] max) -> Integer
           | (Float | ::Range[Float] max) -> Float
 
-  # Returns the seed value used to initialize the generator. This may be
-  # used to initialize another generator with the same state at a later
-  # time, causing it to produce the same sequence of numbers.
-  # 
-  # ```ruby
-  # prng1 = Random.new(1234)
-  # prng1.seed       #=> 1234
-  # prng1.rand(100)  #=> 47
-  # 
-  # prng2 = Random.new(prng1.seed)
-  # prng2.rand(100)  #=> 47
-  # ```
+  # Returns the seed value used to initialize the generator. This may be used to
+  # initialize another generator with the same state at a later time, causing it
+  # to produce the same sequence of numbers.
+  #
+  #     prng1 = Random.new(1234)
+  #     prng1.seed       #=> 1234
+  #     prng1.rand(100)  #=> 47
+  #
+  #     prng2 = Random.new(prng1.seed)
+  #     prng2.rand(100)  #=> 47
+  #
   def seed: () -> Integer
 
-  # Returns an arbitrary seed value. This is used by
-  # [::new](Random.downloaded.ruby_doc#method-c-new) when no seed value is
-  # specified as an argument.
-  # 
-  # ```ruby
-  # Random.new_seed  #=> 115032730400174366788466674494640623225
-  # ```
+  # Returns an arbitrary seed value. This is used by Random.new when no seed value
+  # is specified as an argument.
+  #
+  #     Random.new_seed  #=> 115032730400174366788466674494640623225
+  #
   def self.new_seed: () -> Integer
 
+  # Alias of Random::DEFAULT.rand.
+  #
   def self.rand: (?Integer max) -> Numeric
 
+  # Seeds the system pseudo-random number generator, Random::DEFAULT, with
+  # `number`.  The previous seed value is returned.
+  #
+  # If `number` is omitted, seeds the generator using a source of entropy provided
+  # by the operating system, if available (/dev/urandom on Unix systems or the RSA
+  # cryptographic provider on Windows), which is then combined with the time, the
+  # process id, and a sequence number.
+  #
+  # srand may be used to ensure repeatable sequences of pseudo-random numbers
+  # between different runs of the program. By setting the seed to a known value,
+  # programs can be made deterministic during testing.
+  #
+  #     srand 1234               # => 268519324636777531569100071560086917274
+  #     [ rand, rand ]           # => [0.1915194503788923, 0.6221087710398319]
+  #     [ rand(10), rand(1000) ] # => [4, 664]
+  #     srand 1234               # => 1234
+  #     [ rand, rand ]           # => [0.1915194503788923, 0.6221087710398319]
+  #
   def self.srand: (?Integer number) -> Numeric
 end
 
+# The default Pseudorandom number generator.  Used by class methods of Random.
+#
+#
 Random::DEFAULT: Random
 
+# Format raw random number as Random does
+#
+#
 module Random::Formatter
+  # SecureRandom.base64 generates a random base64 string.
+  #
+  # The argument *n* specifies the length, in bytes, of the random number to be
+  # generated. The length of the result string is about 4/3 of *n*.
+  #
+  # If *n* is not specified or is nil, 16 is assumed. It may be larger in the
+  # future.
+  #
+  # The result may contain A-Z, a-z, 0-9, "+", "/" and "=".
+  #
+  #     require 'securerandom'
+  #
+  #     SecureRandom.base64 #=> "/2BuBuLf3+WfSKyQbRcc/A=="
+  #     SecureRandom.base64 #=> "6BbW0pxO0YENxn38HMUbcQ=="
+  #
+  # If a secure random number generator is not available, `NotImplementedError` is
+  # raised.
+  #
+  # See RFC 3548 for the definition of base64.
+  #
   def base64: (?Integer? n) -> String
 
+  # SecureRandom.hex generates a random hexadecimal string.
+  #
+  # The argument *n* specifies the length, in bytes, of the random number to be
+  # generated. The length of the resulting hexadecimal string is twice of *n*.
+  #
+  # If *n* is not specified or is nil, 16 is assumed. It may be larger in the
+  # future.
+  #
+  # The result may contain 0-9 and a-f.
+  #
+  #     require 'securerandom'
+  #
+  #     SecureRandom.hex #=> "eb693ec8252cd630102fd0d0fb7c3485"
+  #     SecureRandom.hex #=> "91dc3bfb4de5b11d029d376634589b61"
+  #
+  # If a secure random number generator is not available, `NotImplementedError` is
+  # raised.
+  #
   def hex: (?Integer? n) -> String
 
+  # Generates formatted random number from raw random bytes. See Random#rand.
+  #
   def rand: () -> Float
           | (?Float? n) -> Float
           | (?Integer? n) -> Integer
@@ -77,8 +190,26 @@ module Random::Formatter
           | (?::Range[Integer]? n) -> Integer
           | (?::Range[Numeric]? n) -> Numeric
 
+  # SecureRandom.random_bytes generates a random binary string.
+  #
+  # The argument *n* specifies the length of the result string.
+  #
+  # If *n* is not specified or is nil, 16 is assumed. It may be larger in future.
+  #
+  # The result may contain any byte: "x00" - "xff".
+  #
+  #     require 'securerandom'
+  #
+  #     SecureRandom.random_bytes #=> "\xD8\\\xE0\xF4\r\xB2\xFC*WM\xFF\x83\x18\xF45\xB6"
+  #     SecureRandom.random_bytes #=> "m\xDC\xFC/\a\x00Uf\xB2\xB2P\xBD\xFF6S\x97"
+  #
+  # If a secure random number generator is not available, `NotImplementedError` is
+  # raised.
+  #
   def random_bytes: (?Integer? n) -> String
 
+  # Generates formatted random number from raw random bytes. See Random#rand.
+  #
   def random_number: () -> Float
                    | (?Float? n) -> Float
                    | (?Integer? n) -> Integer
@@ -87,7 +218,50 @@ module Random::Formatter
                    | (?::Range[Integer]? n) -> Integer
                    | (?::Range[Numeric]? n) -> Numeric
 
+  # SecureRandom.urlsafe_base64 generates a random URL-safe base64 string.
+  #
+  # The argument *n* specifies the length, in bytes, of the random number to be
+  # generated. The length of the result string is about 4/3 of *n*.
+  #
+  # If *n* is not specified or is nil, 16 is assumed. It may be larger in the
+  # future.
+  #
+  # The boolean argument *padding* specifies the padding. If it is false or nil,
+  # padding is not generated. Otherwise padding is generated. By default, padding
+  # is not generated because "=" may be used as a URL delimiter.
+  #
+  # The result may contain A-Z, a-z, 0-9, "-" and "_". "=" is also used if
+  # *padding* is true.
+  #
+  #     require 'securerandom'
+  #
+  #     SecureRandom.urlsafe_base64 #=> "b4GOKm4pOYU_-BOXcrUGDg"
+  #     SecureRandom.urlsafe_base64 #=> "UZLdOkzop70Ddx-IJR0ABg"
+  #
+  #     SecureRandom.urlsafe_base64(nil, true) #=> "i0XQ-7gglIsHGV2_BNPrdQ=="
+  #     SecureRandom.urlsafe_base64(nil, true) #=> "-M8rLhr7JEpJlqFGUMmOxg=="
+  #
+  # If a secure random number generator is not available, `NotImplementedError` is
+  # raised.
+  #
+  # See RFC 3548 for the definition of URL-safe base64.
+  #
   def urlsafe_base64: (?Integer? n, ?bool padding) -> String
 
+  # SecureRandom.uuid generates a random v4 UUID (Universally Unique IDentifier).
+  #
+  #     require 'securerandom'
+  #
+  #     SecureRandom.uuid #=> "2d931510-d99f-494a-8c67-87feb05e1594"
+  #     SecureRandom.uuid #=> "bad85eb9-0713-4da7-8d36-07a8e4b00eab"
+  #     SecureRandom.uuid #=> "62936e70-1815-439b-bf89-8492855a7e6b"
+  #
+  # The version 4 UUID is purely random (except the version). It doesn't contain
+  # meaningful information such as MAC addresses, timestamps, etc.
+  #
+  # The result contains 122 random bits (15.25 random bytes).
+  #
+  # See RFC 4122 for details of UUID.
+  #
   def uuid: () -> String
 end


### PR DESCRIPTION
The docs were all from the original Sorbet RBI file and were missing docs for a lot of methods, so I've updated them with the `annotate-with-rdoc` script.