### PR TITLE
Add type and test on RbConfig

### DIFF
--- a/stdlib/builtin/rb_config.rbs
+++ b/stdlib/builtin/rb_config.rbs
@@ -18,7 +18,7 @@ module RbConfig
 
   def self.fire_update!: (untyped key, untyped val, ?untyped mkconf, ?untyped conf) -> untyped
 
-  def self.ruby: () -> untyped
+  def self.ruby: () -> String
 end
 
 # The hash configurations stored.

--- a/stdlib/builtin/rb_config.rbs
+++ b/stdlib/builtin/rb_config.rbs
@@ -12,7 +12,7 @@ module RbConfig
   #
   def self.expand: (String val, ?Hash[String, String] config) -> String
 
-  def self.fire_update!: (String key, String val, ?Hash[String, String] mkconf, ?Hash[String, String] conf) -> (Array[String] | nil)
+  def self.fire_update!: (String key, String val, ?Hash[String, String] mkconf, ?Hash[String, String] conf) -> Array[String]?
 
   def self.ruby: () -> String
 end

--- a/stdlib/builtin/rb_config.rbs
+++ b/stdlib/builtin/rb_config.rbs
@@ -1,4 +1,19 @@
+# The module storing Ruby interpreter configurations on building.
+#
+# This file was created by mkconfig.rb when ruby was built.  It contains build
+# information for ruby which is used e.g. by mkmf to build compatible native
+# extensions.  Any changes made to this file will be lost the next time ruby is
+# built.
+#
 module RbConfig
+  # expands variable with given `val` value.
+  #
+  #     RbConfig.expand("$(bindir)") # => /home/foobar/all-ruby/ruby19x/bin
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     RbConfig.expand(val)         -> string
+  #     RbConfig.expand(val, config) -> string
+  #
   def self.expand: (untyped val, ?untyped config) -> untyped
 
   def self.fire_update!: (untyped key, untyped val, ?untyped mkconf, ?untyped conf) -> untyped
@@ -6,10 +21,41 @@ module RbConfig
   def self.ruby: () -> untyped
 end
 
+# The hash configurations stored.
+#
 RbConfig::CONFIG: Hash[String, String]
 
+# DESTDIR on make install.
+#
 RbConfig::DESTDIR: String
 
+# Almost same with CONFIG. MAKEFILE_CONFIG has other variable reference like
+# below.
+#
+#     MAKEFILE_CONFIG["bindir"] = "$(exec_prefix)/bin"
+#
+# The values of this constant is used for creating Makefile.
+#
+#     require 'rbconfig'
+#
+#     print <<-END_OF_MAKEFILE
+#     prefix = #{Config::MAKEFILE_CONFIG['prefix']}
+#     exec_prefix = #{Config::MAKEFILE_CONFIG['exec_prefix']}
+#     bindir = #{Config::MAKEFILE_CONFIG['bindir']}
+#     END_OF_MAKEFILE
+#
+#     => prefix = /usr/local
+#        exec_prefix = $(prefix)
+#        bindir = $(exec_prefix)/bin  MAKEFILE_CONFIG = {}
+#
+# RbConfig.expand is used for resolving references like above in rbconfig.
+#
+#     require 'rbconfig'
+#     p Config.expand(Config::MAKEFILE_CONFIG["bindir"])
+#     # => "/usr/local/bin"
+#
 RbConfig::MAKEFILE_CONFIG: Hash[String, String]
 
+# Ruby installed directory.
+#
 RbConfig::TOPDIR: String

--- a/stdlib/builtin/rb_config.rbs
+++ b/stdlib/builtin/rb_config.rbs
@@ -10,10 +10,6 @@ module RbConfig
   #
   #     RbConfig.expand("$(bindir)") # => /home/foobar/all-ruby/ruby19x/bin
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     RbConfig.expand(val)         -> string
-  #     RbConfig.expand(val, config) -> string
-  #
   def self.expand: (String val, ?Hash[String, String] config) -> String
 
   def self.fire_update!: (String key, String val, ?Hash[String, String] mkconf, ?Hash[String, String] conf) -> Array[String]

--- a/stdlib/builtin/rb_config.rbs
+++ b/stdlib/builtin/rb_config.rbs
@@ -16,7 +16,7 @@ module RbConfig
   #
   def self.expand: (String val, ?Hash[String, String] config) -> String
 
-  def self.fire_update!: (untyped key, untyped val, ?untyped mkconf, ?untyped conf) -> untyped
+  def self.fire_update!: (String key, String val, ?Hash[String, String] mkconf, ?Hash[String, String] conf) -> Array[String]
 
   def self.ruby: () -> String
 end

--- a/stdlib/builtin/rb_config.rbs
+++ b/stdlib/builtin/rb_config.rbs
@@ -12,7 +12,7 @@ module RbConfig
   #
   def self.expand: (String val, ?Hash[String, String] config) -> String
 
-  def self.fire_update!: (String key, String val, ?Hash[String, String] mkconf, ?Hash[String, String] conf) -> Array[String]
+  def self.fire_update!: (String key, String val, ?Hash[String, String] mkconf, ?Hash[String, String] conf) -> (Array[String] | nil)
 
   def self.ruby: () -> String
 end

--- a/stdlib/builtin/rb_config.rbs
+++ b/stdlib/builtin/rb_config.rbs
@@ -1,4 +1,9 @@
 module RbConfig
+  def self.expand: (untyped val, ?untyped config) -> untyped
+
+  def self.fire_update!: (untyped key, untyped val, ?untyped mkconf, ?untyped conf) -> untyped
+
+  def self.ruby: () -> untyped
 end
 
 RbConfig::CONFIG: Hash[String, String]

--- a/stdlib/builtin/rb_config.rbs
+++ b/stdlib/builtin/rb_config.rbs
@@ -14,7 +14,7 @@ module RbConfig
   #     RbConfig.expand(val)         -> string
   #     RbConfig.expand(val, config) -> string
   #
-  def self.expand: (untyped val, ?untyped config) -> untyped
+  def self.expand: (String val, ?Hash[String, String] config) -> String
 
   def self.fire_update!: (untyped key, untyped val, ?untyped mkconf, ?untyped conf) -> untyped
 

--- a/test/stdlib/RbConfig_test.rb
+++ b/test/stdlib/RbConfig_test.rb
@@ -11,6 +11,7 @@ class RbConfigTest < StdlibTest
   end
 
   def test_fire_update!
+    # Add test on nothing changed
     RbConfig.fire_update!("CC", "gcc-8")
     RbConfig.fire_update!("CC", "gcc-8", "UNICODE_VERSION"=>"12.1.0")
     RbConfig.fire_update!("CC", "gcc-8", "UNICODE_VERSION"=>"12.1.0", "PATH_SEPARATOR"=>":")

--- a/test/stdlib/RbConfig_test.rb
+++ b/test/stdlib/RbConfig_test.rb
@@ -10,6 +10,12 @@ class RbConfigTest < StdlibTest
     RbConfig.expand("/home/userName/.rbenv/versions/2.7.0/bin", "UNICODE_VERSION"=>"12.1.0")
   end
 
+  def test_fire_update!
+    RbConfig.fire_update!("CC", "gcc-8")
+    RbConfig.fire_update!("CC", "gcc-8", "UNICODE_VERSION"=>"12.1.0")
+    RbConfig.fire_update!("CC", "gcc-8", "UNICODE_VERSION"=>"12.1.0", "PATH_SEPARATOR"=>":")
+  end
+
   def test_ruby
     RbConfig.ruby
   end

--- a/test/stdlib/RbConfig_test.rb
+++ b/test/stdlib/RbConfig_test.rb
@@ -5,6 +5,11 @@ class RbConfigTest < StdlibTest
 
   using hook.refinement
 
+  def test_expand
+    RbConfig.expand("/home/userName/.rbenv/versions/2.7.0/bin")
+    RbConfig.expand("/home/userName/.rbenv/versions/2.7.0/bin", "UNICODE_VERSION"=>"12.1.0")
+  end
+
   def test_ruby
     RbConfig.ruby
   end

--- a/test/stdlib/RbConfig_test.rb
+++ b/test/stdlib/RbConfig_test.rb
@@ -1,0 +1,11 @@
+require_relative "test_helper"
+
+class RbConfigTest < StdlibTest
+  target RbConfig
+
+  using hook.refinement
+
+  def test_ruby
+    RbConfig.ruby
+  end
+end


### PR DESCRIPTION
## Description

I add type and test on RbConfig. If you OK, Once I want to merge this.

## Not Done

- Add RbConfig.fire_update! return nil. For now, I am wondering how to add a test.

## Reference

- https://docs.ruby-lang.org/ja/2.7.0/class/RbConfig.html#S_RUBY
- https://github.com/ruby/ruby/blob/db166290088fb7d39d01f68b9860253893d4f1a7/tool/mkconfig.rb
