### PR TITLE
Add a script for finding missing methods and aliases in an RBS.

### DIFF
--- a/bin/find_missing
+++ b/bin/find_missing
@@ -1,0 +1,94 @@
+#!/usr/bin/env ruby
+
+require "ruby/signature"
+require "optparse"
+
+Members = Ruby::Signature::AST::Members
+
+def get_methods_and_aliases(decls)
+  methods = []
+  aliases = []
+
+  decls.each do |sig|
+    case sig
+    when Ruby::Signature::AST::Declarations::Class, Ruby::Signature::AST::Declarations::Module, Ruby::Signature::AST::Declarations::Interface
+      sig.members.each do |member|
+        case member
+        when Members::Alias
+          aliases << "alias #{member.new_name} #{member.old_name}"
+        when Members::MethodDefinition
+          methods << "#{member.kind == :singleton ? 'self.' : ''}#{member.name}"
+        end
+      end
+    end
+  end
+
+  return methods, aliases
+end
+
+def get_decls_from_runtime
+  require_libs = []
+  relative_libs = []
+  merge = false
+  owners_included = []
+  klasses = []
+
+  OptionParser.new do |opts|
+    opts.on("--require=[LIB]") do |lib|
+      require_libs << lib
+    end
+    opts.on("--require-relative=[LIB]") do |lib|
+      relative_libs << lib
+    end
+    opts.on("--merge") do
+      merge = true
+    end
+    opts.on("--method-owner=[CLASS]") do |klass|
+      owners_included << klass
+    end
+    opts.on("--patterns=[CLASS]") do |klass|
+      klasses << klass
+    end
+  end.parse!
+
+  require(*require_libs) unless require_libs.empty?
+  require_relative(*relative_libs) unless relative_libs.empty?
+
+  return Ruby::Signature::Prototype::Runtime.new(patterns: klasses, env: [], merge: merge, owners_included: owners_included).decls
+end
+
+decls = get_decls_from_runtime()
+sigs = []
+
+ARGV.map {|f| Pathname(f) }.each do |path|
+  puts "Opening #{path}..."
+
+  buffer = Ruby::Signature::Buffer.new(name: path, content: path.read)
+  sigs.concat(Ruby::Signature::Parser.parse_signature(buffer))
+end
+
+file_methods, file_aliases = get_methods_and_aliases(sigs)
+runtime_methods, runtime_aliases = get_methods_and_aliases(decls)
+
+missing_methods = runtime_methods.difference(file_methods)
+missing_aliases = runtime_aliases.difference(file_aliases)
+
+if missing_methods.empty?
+  puts "No missing methods."
+else
+  puts "Missing methods:"
+  missing_methods.each do |meth|
+    puts "- #{meth}"
+  end
+end
+
+puts
+
+if missing_aliases.empty?
+  puts "No missing aliases."
+else
+  puts "Missing aliases:"
+  missing_aliases.each do |al|
+    puts "- #{al}"
+  end
+end


### PR DESCRIPTION
I wrote a script to find methods and aliases that are missing from an RBS by using the runtime prototyper:

```
ruby-signature connorshea$ bundle exec bin/find_missing --patterns=Module stdlib/builtin/module.rbs
Opening stdlib/builtin/module.rbs...
Missing methods:
- const_source_location
- deprecate_constant
- pretty_print
- pretty_print_cycle
- undef_method
- initialize_clone
- initialize_copy
- method_undefined
- ruby2_keywords

Missing aliases:
- alias inspect to_s
```

It can be used like so:
- `bundle exec bin/find_missing --patterns=Module stdlib/builtin/module.rbs`
- `bundle exec bin/find_missing --patterns=Set stdlib/set/set.rbs`.

It's pretty hacky, and there are still some problems with it:

- It lists methods that are mixed in from other classes/modules, like `pretty_print`.
- The way it outputs the aliases and methods is not ideal, it should probably be done in a way that can be copy-pasted into the file.
- It doesn't understand `module_function` methods (e.g. `self?.foo`), so it incorrectly marks some methods as missing when they shouldn't be.
- It doesn't handle files with multiple classes/modules correctly right now.

The idea with this is that it'd be useful for finding methods that still need to be added to a class, e.g. `Module#deprecate_constant` isn't included in `module.rbs`.

Is there interest in merging this? I wanted to get feedback before continuing :)