### PR TITLE
Fix CLI option handling

### DIFF
--- a/lib/ruby/signature/cli.rb
+++ b/lib/ruby/signature/cli.rb
@@ -424,16 +424,16 @@ module Ruby
           owners_included = []
 
           OptionParser.new do |opts|
-            opts.on("--require=[LIB]") do |lib|
+            opts.on("--require LIB") do |lib|
               require_libs << lib
             end
-            opts.on("--require-relative=[LIB]") do |lib|
+            opts.on("--require-relative LIB") do |lib|
               relative_libs << lib
             end
             opts.on("--merge") do
               merge = true
             end
-            opts.on("--method-owner=[CLASS]") do |klass|
+            opts.on("--method-owner CLASS") do |klass|
               owners_included << klass
             end
           end.parse!(args)
@@ -445,8 +445,13 @@ module Ruby
           env = Environment.new()
           loader.load(env: env)
 
-          require(*require_libs) unless require_libs.empty?
-          require_relative(*relative_libs) unless relative_libs.empty?
+          require_libs.each do |lib|
+            require(lib)
+          end
+
+          relative_libs.each do |lib|
+            require(lib)
+          end
 
           decls = Prototype::Runtime.new(patterns: args, env: env, merge: merge, owners_included: owners_included).decls
         else


### PR DESCRIPTION
- `--require`, `--require-relative` and `--method-owner` need argument
- `opts.on("--require=[LIB]")` only accepts `--require=json`, it doesn't recognize `--require json`
- `require` and `require_relative` don't accept array

## Before

```
$ bundle exec rbs prototype runtime --require json NilClass
bundler: failed to load command: rbs (/app/vendor/bundle/ruby/2.7.0/bin/rbs)
TypeError: no implicit conversion of nil into String
  /app/lib/ruby/signature/cli.rb:448:in `require'
  /app/lib/ruby/signature/cli.rb:448:in `run_prototype'
  /app/lib/ruby/signature/cli.rb:86:in `run'
  /app/exe/ruby-signature:7:in `<top (required)>'
  /app/exe/rbs:3:in `load'
  /app/exe/rbs:3:in `<top (required)>'
  /app/vendor/bundle/ruby/2.7.0/bin/rbs:23:in `load'
  /app/vendor/bundle/ruby/2.7.0/bin/rbs:23:in `<top (required)>'

$ bundle exec rbs prototype runtime --require json --require pathname NilClass
bundler: failed to load command: rbs (/app/vendor/bundle/ruby/2.7.0/bin/rbs)
ArgumentError: wrong number of arguments (given 2, expected 1)
  /app/lib/ruby/signature/cli.rb:448:in `require'
  /app/lib/ruby/signature/cli.rb:448:in `run_prototype'
  /app/lib/ruby/signature/cli.rb:86:in `run'
  /app/exe/ruby-signature:7:in `<top (required)>'
  /app/exe/rbs:3:in `load'
  /app/exe/rbs:3:in `<top (required)>'
  /app/vendor/bundle/ruby/2.7.0/bin/rbs:23:in `load'
  /app/vendor/bundle/ruby/2.7.0/bin/rbs:23:in `<top (required)>'
```

## After

```
$ bundle exec rbs prototype runtime --require json --require pathname NilClass
class NilClass
  include JSON::Ext::Generator::GeneratorMethods::NilClass

  public

  def &: (untyped) -> untyped

  def ===: (untyped) -> untyped

  def =~: (untyped) -> untyped

  def ^: (untyped) -> untyped

  def inspect: () -> untyped

  def nil?: () -> untyped

  def pretty_print_cycle: (untyped q) -> untyped

  def rationalize: (*untyped) -> untyped

  def to_a: () -> untyped

  def to_c: () -> untyped

  def to_f: () -> untyped

  def to_h: () -> untyped

  def to_i: () -> untyped

  def to_r: () -> untyped

  def to_s: () -> untyped

  def |: (untyped) -> untyped
end
```