### PR TITLE
Avoid output duplicated rb prototype

### DIFF
--- a/lib/ruby/signature/ast/declarations.rb
+++ b/lib/ruby/signature/ast/declarations.rb
@@ -20,6 +20,12 @@ module Ruby
             other.is_a?(ModuleTypeParams) && other.params == params
           end
 
+          alias eql? ==
+
+          def hash
+            params.hash
+          end
+
           def [](name)
             params.find {|p| p.name == name }
           end

--- a/lib/ruby/signature/prototype/rb.rb
+++ b/lib/ruby/signature/prototype/rb.rb
@@ -28,7 +28,7 @@ module Ruby
             decls << top
           end
 
-          decls
+          decls.uniq
         end
 
         def parse(string)

--- a/test/ruby/signature/rb_prototype_test.rb
+++ b/test/ruby/signature/rb_prototype_test.rb
@@ -393,4 +393,33 @@ class C
 end
     EOF
   end
+
+  def test_multiple_nested_class
+    parser = RB.new
+
+    rb = <<-'EOR'
+module Foo
+  class Bar
+  end
+end
+
+module Foo
+  class Baz
+  end
+end
+    EOR
+
+    parser.parse(rb)
+
+    assert_write parser.decls, <<-EOF
+module Foo
+end
+
+class Foo::Bar
+end
+
+class Foo::Baz
+end
+    EOF
+  end
 end


### PR DESCRIPTION
Let's say we have the following ruby file foo.rb:

```ruby
module Foo
  class Bar
  end
end

module Foo
  class Baz
  end
end
```

## Before

```
$ bundle exec rbs prototype rb foo.rb
module Foo
end

class Foo::Bar
end

module Foo
end

class Foo::Baz
end
```

## After

```
$ bundle exec rbs prototype rb foo.rb
module Foo
end

class Foo::Bar
end

class Foo::Baz
end
```