### PR TITLE
Add signatures for IPAddr.

### DIFF
--- a/stdlib/ipaddr/ipaddr.rbs
+++ b/stdlib/ipaddr/ipaddr.rbs
@@ -25,12 +25,12 @@ class IPAddr
   # Creates a new ipaddr containing the given network byte ordered string form of
   # an IP address.
   #
-  def self.new_ntoh: (untyped addr) -> IPAddr
+  def self.new_ntoh: (String addr) -> IPAddr
 
   # Convert a network byte ordered string form of an IP address into human
   # readable form.
   #
-  def self.ntop: (untyped addr) -> String
+  def self.ntop: (String addr) -> String
 
   # Creates a new ipaddr object either from a human readable IP address
   # representation in string, or from a packed in_addr value followed by an
@@ -58,7 +58,7 @@ class IPAddr
 
   # Returns a new ipaddr built by bitwise left shift.
   #
-  def <<: (untyped num) -> IPAddr
+  def <<: (Integer num) -> IPAddr
 
   # Compares the ipaddr with another.
   #
@@ -72,7 +72,7 @@ class IPAddr
 
   # Returns a new ipaddr built by bitwise right-shift.
   #
-  def >>: (untyped num) -> IPAddr
+  def >>: (Integer num) -> IPAddr
 
   # Checks equality used by Hash.
   #

--- a/stdlib/ipaddr/ipaddr.rbs
+++ b/stdlib/ipaddr/ipaddr.rbs
@@ -50,9 +50,6 @@ class IPAddr
   # as &, |, include? and ==, accept a string, or a packed in_addr value instead
   # of an IPAddr object.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     new(addr = '::', family = Socket::AF_UNSPEC)
-  #
   def initialize: (?String addr, ?untyped family) -> IPAddr
 
   # Returns a new ipaddr built by bitwise AND.
@@ -212,6 +209,29 @@ class IPAddr
   # Returns a new ipaddr built by bitwise negation.
   #
   def ~: () -> IPAddr
+end
+
+# Generic IPAddr related error. Exceptions raised in this class should inherit
+# from Error.
+#
+class IPAddr::Error < ArgumentError
+end
+
+# Raised when the provided IP address is an invalid address.
+#
+class IPAddr::InvalidAddressError < IPAddr::Error
+end
+
+# Raised when the address family is invalid such as an address with an
+# unsupported family, an address with an inconsistent family, or an address
+# who's family cannot be determined.
+#
+class IPAddr::AddressFamilyError < IPAddr::Error
+end
+
+# Raised when the address is an invalid length.
+#
+class IPAddr::InvalidPrefixError < IPAddr::InvalidAddressError
 end
 
 # 32 bit mask for IPv4

--- a/stdlib/ipaddr/ipaddr.rbs
+++ b/stdlib/ipaddr/ipaddr.rbs
@@ -1,0 +1,204 @@
+# IPAddr provides a set of methods to manipulate an IP address.  Both IPv4 and
+# IPv6 are supported.
+#
+# ## Example
+#
+#     require 'ipaddr'
+#
+#     ipaddr1 = IPAddr.new "3ffe:505:2::1"
+#
+#     p ipaddr1                   #=> #<IPAddr: IPv6:3ffe:0505:0002:0000:0000:0000:0000:0001/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff>
+#
+#     p ipaddr1.to_s              #=> "3ffe:505:2::1"
+#
+#     ipaddr2 = ipaddr1.mask(48)  #=> #<IPAddr: IPv6:3ffe:0505:0002:0000:0000:0000:0000:0000/ffff:ffff:ffff:0000:0000:0000:0000:0000>
+#
+#     p ipaddr2.to_s              #=> "3ffe:505:2::"
+#
+#     ipaddr3 = IPAddr.new "192.168.2.0/24"
+#
+#     p ipaddr3                   #=> #<IPAddr: IPv4:192.168.2.0/255.255.255.0>
+#
+class IPAddr
+  include Comparable
+
+  # Creates a new ipaddr containing the given network byte ordered string form of
+  # an IP address.
+  #
+  def self.new_ntoh: (untyped addr) -> IPAddr
+
+  # Convert a network byte ordered string form of an IP address into human
+  # readable form.
+  #
+  def self.ntop: (untyped addr) -> String
+
+  # Returns a new ipaddr built by bitwise AND.
+  #
+  def &: (untyped other) -> IPAddr
+
+  # Returns a new ipaddr built by bitwise left shift.
+  #
+  def <<: (untyped num) -> IPAddr
+
+  # Compares the ipaddr with another.
+  #
+  def <=>: (untyped other) -> Integer?
+
+  # Returns true if two ipaddrs are equal.
+  #
+  def ==: (untyped other) -> bool
+
+  alias === include?
+
+  # Returns a new ipaddr built by bitwise right-shift.
+  #
+  def >>: (untyped num) -> untyped
+
+  # Checks equality used by Hash.
+  #
+  def eql?: (untyped other) -> untyped
+
+  # Returns the address family of this IP address.
+  #
+  def family: () -> untyped
+
+  # Returns a hash value used by Hash, Set, and Array classes
+  #
+  def hash: () -> untyped
+
+  # Returns a network byte ordered string form of the IP address.
+  #
+  def hton: () -> untyped
+
+  # Returns true if the given ipaddr is in the range.
+  #
+  # e.g.:
+  #     require 'ipaddr'
+  #     net1 = IPAddr.new("192.168.2.0/24")
+  #     net2 = IPAddr.new("192.168.2.100")
+  #     net3 = IPAddr.new("192.168.3.0")
+  #     p net1.include?(net2)     #=> true
+  #     p net1.include?(net3)     #=> false
+  #
+  def include?: (untyped other) -> bool
+
+  # Returns a string containing a human-readable representation of the ipaddr.
+  # ("#<IPAddr: family:address/mask>")
+  #
+  def inspect: () -> String
+
+  # Returns a string for DNS reverse lookup compatible with RFC3172.
+  #
+  def ip6_arpa: () -> String
+
+  # Returns a string for DNS reverse lookup compatible with RFC1886.
+  #
+  def ip6_int: () -> String
+
+  # Returns true if the ipaddr is an IPv4 address.
+  #
+  def ipv4?: () -> bool
+
+  # Returns a new ipaddr built by converting the native IPv4 address into an
+  # IPv4-compatible IPv6 address.
+  #
+  def ipv4_compat: () -> IPAddr
+
+  # Returns true if the ipaddr is an IPv4-compatible IPv6 address.
+  #
+  def ipv4_compat?: () -> bool
+
+  # Returns a new ipaddr built by converting the native IPv4 address into an
+  # IPv4-mapped IPv6 address.
+  #
+  def ipv4_mapped: () -> IPAddr
+
+  # Returns true if the ipaddr is an IPv4-mapped IPv6 address.
+  #
+  def ipv4_mapped?: () -> bool
+
+  # Returns true if the ipaddr is an IPv6 address.
+  #
+  def ipv6?: () -> bool
+
+  # Returns true if the ipaddr is a link-local address.  IPv4 addresses in
+  # 169.254.0.0/16 reserved by RFC 3927 and Link-Local IPv6 Unicast Addresses in
+  # fe80::/10 reserved by RFC 4291 are considered link-local.
+  #
+  def link_local?: () -> bool
+
+  # Returns true if the ipaddr is a loopback address.
+  #
+  def loopback?: () -> bool
+
+  # Returns a new ipaddr built by masking IP address with the given
+  # prefixlen/netmask. (e.g. 8, 64, "255.255.255.0", etc.)
+  #
+  def mask: (untyped prefixlen) -> IPAddr
+
+  # Returns a new ipaddr built by converting the IPv6 address into a native IPv4
+  # address.  If the IP address is not an IPv4-mapped or IPv4-compatible IPv6
+  # address, returns self.
+  #
+  def native: () -> IPAddr
+
+  # Returns the prefix length in bits for the ipaddr.
+  #
+  def prefix: () -> Integer
+
+  # Sets the prefix length in bits
+  #
+  def prefix=: (Integer prefix) -> self
+
+  # Returns true if the ipaddr is a private address.  IPv4 addresses in
+  # 10.0.0.0/8, 172.16.0.0/12 and 192.168.0.0/16 as defined in RFC 1918 and IPv6
+  # Unique Local Addresses in fc00::/7 as defined in RFC 4193 are considered
+  # private.
+  #
+  def private?: () -> bool
+
+  # Returns a string for DNS reverse lookup.  It returns a string in RFC3172 form
+  # for an IPv6 address.
+  #
+  def reverse: () -> String
+
+  # Returns the successor to the ipaddr.
+  #
+  def succ: () -> untyped
+
+  # Returns the integer representation of the ipaddr.
+  #
+  def to_i: () -> Integer
+
+  # Creates a Range object for the network address.
+  #
+  def to_range: () -> Range[IPAddr]
+
+  # Returns a string containing the IP address representation.
+  #
+  def to_s: () -> String
+
+  # Returns a string containing the IP address representation in canonical form.
+  #
+  def to_string: () -> String
+
+  # Returns a new ipaddr built by bitwise OR.
+  #
+  def |: (untyped other) -> IPAddr
+
+  # Returns a new ipaddr built by bitwise negation.
+  #
+  def ~: () -> IPAddr
+end
+
+# 32 bit mask for IPv4
+#
+IPAddr::IN4MASK: Integer
+
+# Format string for IPv6
+#
+IPAddr::IN6FORMAT: String
+
+# 128 bit mask for IPv6
+#
+IPAddr::IN6MASK: Integer

--- a/stdlib/ipaddr/ipaddr.rbs
+++ b/stdlib/ipaddr/ipaddr.rbs
@@ -32,6 +32,29 @@ class IPAddr
   #
   def self.ntop: (untyped addr) -> String
 
+  # Creates a new ipaddr object either from a human readable IP address
+  # representation in string, or from a packed in_addr value followed by an
+  # address family.
+  #
+  # In the former case, the following are the valid formats that will be
+  # recognized: "address", "address/prefixlen" and "address/mask", where IPv6
+  # address may be enclosed in square brackets (`[' and `]').  If a prefixlen or a
+  # mask is specified, it returns a masked IP address.  Although the address
+  # family is determined automatically from a specified string, you can specify
+  # one explicitly by the optional second argument.
+  #
+  # Otherwise an IP address is generated from a packed in_addr value and an
+  # address family.
+  #
+  # The IPAddr class defines many methods and operators, and some of those, such
+  # as &, |, include? and ==, accept a string, or a packed in_addr value instead
+  # of an IPAddr object.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     new(addr = '::', family = Socket::AF_UNSPEC)
+  #
+  def initialize: (?String addr, ?untyped family) -> IPAddr
+
   # Returns a new ipaddr built by bitwise AND.
   #
   def &: (untyped other) -> IPAddr

--- a/stdlib/ipaddr/ipaddr.rbs
+++ b/stdlib/ipaddr/ipaddr.rbs
@@ -72,23 +72,23 @@ class IPAddr
 
   # Returns a new ipaddr built by bitwise right-shift.
   #
-  def >>: (untyped num) -> untyped
+  def >>: (untyped num) -> IPAddr
 
   # Checks equality used by Hash.
   #
-  def eql?: (untyped other) -> untyped
+  def eql?: (untyped other) -> bool
 
   # Returns the address family of this IP address.
   #
-  def family: () -> untyped
+  attr_reader family: Integer
 
   # Returns a hash value used by Hash, Set, and Array classes
   #
-  def hash: () -> untyped
+  def hash: () -> Integer
 
   # Returns a network byte ordered string form of the IP address.
   #
-  def hton: () -> untyped
+  def hton: () -> String
 
   # Returns true if the given ipaddr is in the range.
   #
@@ -154,7 +154,7 @@ class IPAddr
   # Returns a new ipaddr built by masking IP address with the given
   # prefixlen/netmask. (e.g. 8, 64, "255.255.255.0", etc.)
   #
-  def mask: (untyped prefixlen) -> IPAddr
+  def mask: (String | Integer prefixlen) -> IPAddr
 
   # Returns a new ipaddr built by converting the IPv6 address into a native IPv4
   # address.  If the IP address is not an IPv4-mapped or IPv4-compatible IPv6
@@ -184,7 +184,7 @@ class IPAddr
 
   # Returns the successor to the ipaddr.
   #
-  def succ: () -> untyped
+  def succ: () -> IPAddr
 
   # Returns the integer representation of the ipaddr.
   #

--- a/test/stdlib/IPAddr_test.rb
+++ b/test/stdlib/IPAddr_test.rb
@@ -1,0 +1,79 @@
+require_relative "test_helper"
+
+class IPAddrTest < StdlibTest
+  target IPAddr
+  library "ipaddr"
+  using hook.refinement
+
+  def test_hash
+    IPAddr.new("192.168.2.0/24").hash
+  end
+
+  def test_hton
+    IPAddr.new("192.168.2.0/24").hton
+  end
+
+  def test_include?
+    net1 = IPAddr.new("192.168.2.0/24")
+    net2 = IPAddr.new("192.168.2.100")
+    net3 = IPAddr.new("192.168.3.0")
+    net1.include?(net2)
+    net1.include?(net3)
+  end
+
+  def test_inspect
+    IPAddr.new("192.168.2.0/24").inspect
+  end
+
+  def test_ip6_arpa
+    IPAddr.new("3ffe:505:2::1").ip6_arpa
+  end
+
+  def test_ip6_int
+    IPAddr.new("3ffe:505:2::1").ip6_int
+  end
+
+  def test_ipv4?
+    IPAddr.new("3ffe:505:2::1").ipv4?
+  end
+
+  def test_ipv4_mapped
+    IPAddr.new("192.168.3.0").ipv4_mapped
+  end
+
+  def test_ipv6?
+    IPAddr.new("3ffe:505:2::1").ipv6?
+  end
+
+  def test_link_local?
+    IPAddr.new("3ffe:505:2::1").link_local?
+  end
+
+  def test_loopback?
+    IPAddr.new("3ffe:505:2::1").loopback?
+  end
+
+  def test_prefix
+    IPAddr.new("192.168.2.0/24").prefix
+  end
+
+  def test_private?
+    IPAddr.new("3ffe:505:2::1").private?
+  end
+
+  def test_reverse
+    IPAddr.new("3ffe:505:2::1").reverse
+  end
+
+  def test_succ
+    IPAddr.new("192.168.2.0/24").succ
+  end
+
+  def test_to_i
+    IPAddr.new("192.168.2.0/24").to_i
+  end
+
+  def test_to_string
+    IPAddr.new("192.168.2.0/24").to_string
+  end
+end


### PR DESCRIPTION
Based on [`ipaddr.rb`](https://github.com/ruby/ruby/blob/cf191872fdeade823b4c49b53ec9b28d66a5c402/lib/ipaddr.rb).

I'm not sure if the error classes should be included in the RBS file?

e.g. from that file:
```ruby
class IPAddr
  # Generic IPAddr related error. Exceptions raised in this class should
  # inherit from Error.
  class Error < ArgumentError; end
end
```

I didn't include them here, but I can add them if they should be added.