### PR TITLE
Allow coments without leading space

### DIFF
--- a/lib/ruby/signature/parser.y
+++ b/lib/ruby/signature/parser.y
@@ -1244,7 +1244,7 @@ def next_token
     case
     when input.scan(/\s+/)
       # skip
-    when input.scan(/#(( *)|( (?<string>.*)))\n/)
+    when input.scan(/#(( *)|( ?(?<string>.*)))\n/)
       start_index = input.charpos - input.matched.size
       end_index = input.charpos-1
 

--- a/test/ruby/signature/signature_parsing_test.rb
+++ b/test/ruby/signature/signature_parsing_test.rb
@@ -875,6 +875,32 @@ EOF
     end
   end
 
+  def test_comment_without_leading_space
+    Parser.parse_signature(<<-EOF).yield_self do |foo_decl,|
+#This is a class.
+class Foo
+  #This is a method.
+  def bar: () -> void
+
+  #def baz: () -> void
+end
+EOF
+
+      assert_instance_of Declarations::Class, foo_decl
+
+      assert_equal <<EOF, foo_decl.comment.string
+This is a class.
+EOF
+
+      foo_decl.members[0].tap do |member|
+        assert_instance_of Members::MethodDefinition, member
+        assert_equal <<EOF, member.comment.string
+This is a method.
+EOF
+      end
+    end
+  end
+
   def test_parsing_quoted_method_name
     Parser.parse_signature(<<-EOF).yield_self do |foo_decl,|
 module Kernel


### PR DESCRIPTION
I was working signatures for my code and noticed that parser can not handle comments without a space after `#`.

Example:
```
class Foo
  #def baz: () -> void
end
```

I was getting exceptions from the parser. Which is not a nice thing to have.

So now parser can handle all comments and removes one leading space from comments for nicer layout as it used to.