### PR TITLE
Remove `(Numeric) -> Numeric` rules from some Integer binary methods

### DIFF
--- a/stdlib/builtin/integer.rbs
+++ b/stdlib/builtin/integer.rbs
@@ -45,7 +45,6 @@ class Integer < Numeric
        | (Rational) -> Rational
        | (Complex) -> Complex
        | (Integer) -> Integer
-       | (Numeric) -> Numeric
 
   # Raises `int` to the power of `numeric`, which may be negative or fractional.
   # The result may be an Integer, a Float, a Rational, or a complex number.
@@ -63,7 +62,6 @@ class Integer < Numeric
         | (Float) -> Numeric
         | (Rational) -> Numeric
         | (Complex) -> Complex
-        | (Numeric) -> Numeric
 
   # Performs addition: the class of the resulting object depends on the class of
   # `numeric`.
@@ -72,7 +70,6 @@ class Integer < Numeric
        | (Float) -> Float
        | (Rational) -> Rational
        | (Complex) -> Complex
-       | (Numeric) -> Numeric
 
   def +@: () -> Integer
 
@@ -83,7 +80,6 @@ class Integer < Numeric
        | (Float) -> Float
        | (Rational) -> Rational
        | (Complex) -> Complex
-       | (Numeric) -> Numeric
 
   # Returns `int`, negated.
   #
@@ -96,7 +92,6 @@ class Integer < Numeric
        | (Float) -> Float
        | (Rational) -> Rational
        | (Complex) -> Complex
-       | (Numeric) -> Numeric
 
   # Returns `true` if the value of `int` is less than that of `real`.
   #
@@ -475,7 +470,6 @@ class Integer < Numeric
   #     a.pow(b, m)  #=> same as (a**b) % m, but avoids huge temporary values
   #
   def pow: (Integer other, ?Integer modulo) -> Integer
-         | (Numeric numeric) -> Numeric
 
   # Returns the predecessor of `int`, i.e. the Integer equal to `int-1`.
   #

--- a/stdlib/builtin/integer.rbs
+++ b/stdlib/builtin/integer.rbs
@@ -470,6 +470,9 @@ class Integer < Numeric
   #     a.pow(b, m)  #=> same as (a**b) % m, but avoids huge temporary values
   #
   def pow: (Integer other, ?Integer modulo) -> Integer
+         | (Float) -> Float
+         | (Rational) -> Rational
+         | (Complex) -> Complex
 
   # Returns the predecessor of `int`, i.e. the Integer equal to `int-1`.
   #


### PR DESCRIPTION
for two reasons:

(1) These rules are less useful.  If a class inherits from Numeric, it
should use `extension` to extend the overloading for `Integer#+`, `#-`,
etc.  Without the extension, `1 + its_instance` returns `Numeric`, but
it would be difficult to use the result correctly.
Note that Liskov substitution principle does not matter here because
there is no `Numeric#+`, `#-`, etc.

(2) Type Profiler tries all overloaded rules that matches the argument
types at each call.  So, `1 + 1` is considered as `Integer | Numeric`
because `1` is an Integer and Integer is Numeric.  This is not wrong but
too conservative, so I'd like to avoid it.