### PR TITLE
Fix Kernel#printf signature

### DIFF
--- a/stdlib/builtin/kernel.rbs
+++ b/stdlib/builtin/kernel.rbs
@@ -384,7 +384,9 @@ module Kernel
   #     cat, 1, 2, 3, 99
   def print: (*Kernel args) -> nil
 
-  def printf: (?IO arg0, ?String arg1, *untyped arg2) -> nil
+  def printf: (IO arg0, String arg1, *untyped args) -> nil
+            | (String arg1, *untyped args) -> nil
+            | -> nil
 
   def proc: () { () -> untyped } -> Proc
 

--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -455,6 +455,7 @@ class KernelTest < StdlibTest
     #   printf 's'
     #   printf '%d', 2
     #   printf '%d%s', 2, 1
+    #   printf
   ensure
     $stdout = STDOUT
   end


### PR DESCRIPTION
`printf: (?IO, ?String, *untyped) -> nil` wrongly accepts `printf(1)`.