### PR TITLE
Fix typing of `fail` and add tests

### DIFF
--- a/stdlib/builtin/builtin.rbs
+++ b/stdlib/builtin/builtin.rbs
@@ -30,6 +30,11 @@ interface _Each[out A, out B]
   def each: { (A) -> void } -> B
 end
 
+interface _Exception
+  def exception: () -> Exception
+               | (String arg0) -> Exception
+end
+
 class BigDecimal
 end
 

--- a/stdlib/builtin/kernel.rbs
+++ b/stdlib/builtin/kernel.rbs
@@ -302,19 +302,19 @@ module Kernel
   # The optional second parameter sets the message associated with the
   # exception, and the third parameter is an array of callback information.
   # Exceptions are caught by the `rescue` clause of `begin...end` blocks.
-  # 
+  #
   # ```ruby
   # raise "Failed to create socket"
   # raise ArgumentError, "No parameters", caller
   # ```
-  # 
+  #
   # The `cause` of the generated exception is automatically set to the
   # “current” exception ( `$!` ) if any. An alternative value, either an
   # `Exception` object or `nil`, can be specified via the `:cause`
   # argument.
   def fail: () -> bot
           | (String arg0) -> bot
-          | (?Exception arg0, ?String arg1, ?::Array[String] arg2) -> bot
+          | (_Exception arg0, ?untyped arg1, ?::Array[String] arg2) -> bot
   alias raise fail
 
   def format: (String format, *untyped args) -> String

--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -402,7 +402,52 @@ class KernelTest < StdlibTest
   end
 
   def test_fail
-    # TODO
+    begin
+      fail
+    rescue RuntimeError
+    end
+
+    begin
+      fail 'error'
+    rescue RuntimeError
+    end
+
+    test_error = Class.new(StandardError)
+    begin
+      fail test_error
+    rescue test_error
+    end
+
+    begin
+      fail test_error, 'a'
+    rescue test_error
+    end
+
+    begin
+      fail test_error, 'a', ['1.rb, 2.rb']
+    rescue test_error
+    end
+
+    begin
+      fail test_error.new('a')
+    rescue test_error
+    end
+
+    exception_container = Class.new do
+      def exception(arg: 'a')
+        test_error.new(arg)
+      end
+    end
+
+    begin
+      fail exception_container.new
+    rescue test_error
+    end
+
+    begin
+      fail exception_container.new, 14
+    rescue test_error
+    end
   end
 
   def test_format


### PR DESCRIPTION
Hi there. I was trying to add signature to an existing project, and found that checking through steep was failing on a few `raise` calls.

Previous the following forms would fail checking:

```ruby
raise Exception, 'message'
raise object_that_implements_exception_method
```

My understanding of the first argument to `raise` is that it can be anything that adheres to the exception interface of exposing a `exception` method. Switching `?Exception` for the interface `_Exception` allows for exception classes, exception instances, and objects that adhere to that interface to all pass checking.